### PR TITLE
chore: initial structure

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v2.5.1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci

--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -6,16 +6,13 @@ name: Node.js CI and publish
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
-
 jobs:
   build:
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/dynamodb/get-item.js
+++ b/dynamodb/get-item.js
@@ -1,0 +1,19 @@
+const { GetCommand } = require('@aws-sdk/lib-dynamodb');
+
+async function getItem(documentClient, tableName, key) {
+  if (!tableName) throw new Error('Table name is required.');
+  if (!key) throw new Error('Key is required.');
+  if (typeof key !== 'object') throw new Error('Key should be an object.');
+
+  const input = {
+    TableName: tableName,
+    Key: key
+  };
+
+  const command = new GetCommand(input);
+  const response = await documentClient.send(command);
+
+  return response?.Item || null;
+}
+
+module.exports = getItem;

--- a/dynamodb/get-item.test.js
+++ b/dynamodb/get-item.test.js
@@ -1,0 +1,40 @@
+const { mockClient } = require('aws-sdk-client-mock');
+const { GetCommand, DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
+
+const dynamoDbDocumentMock = mockClient(DynamoDBDocument);
+
+const getItem = require('./get-item');
+
+describe('get-item', () => {
+  it('should validate table', async () => {
+    await expect(getItem(dynamoDbDocumentMock, '', {})).rejects.toThrow(
+      'Table name is required.'
+    );
+  });
+
+  it('should validate key', async () => {
+    await expect(getItem(dynamoDbDocumentMock, 'table')).rejects.toThrow(
+      'Key is required.'
+    );
+  });
+
+  it('should validate that key key is object', async () => {
+    await expect(getItem(dynamoDbDocumentMock, 'table', 'id')).rejects.toThrow(
+      'Key should be an object.'
+    );
+  });
+
+  it('should return item', async () => {
+    dynamoDbDocumentMock.on(GetCommand).resolves({ Item: { Id: 5 } });
+
+    const result = await getItem(dynamoDbDocumentMock, 'table', {});
+    expect(result.Id).toEqual(5);
+  });
+
+  it('should handle null repsonse', async () => {
+    dynamoDbDocumentMock.on(GetCommand).resolves(null);
+
+    const result = await getItem(dynamoDbDocumentMock, 'table', {});
+    expect(result).toBeNull();
+  });
+});

--- a/dynamodb/scan.js
+++ b/dynamodb/scan.js
@@ -1,5 +1,0 @@
-async function scan() {
-  return [];
-}
-
-module.exports = scan;

--- a/dynamodb/scan.test.js
+++ b/dynamodb/scan.test.js
@@ -1,5 +1,0 @@
-describe('dummy test', () => {
-  it('should be true', () => {
-    expect(true).toBeTruthy();
-  });
-});

--- a/index.js
+++ b/index.js
@@ -1,5 +1,13 @@
-const scan = require('./dynamodb/scan');
+const { DynamoDB } = require('@aws-sdk/client-dynamodb');
+const { DynamoDBDocument } = require('@aws-sdk/lib-dynamodb');
 
-module.exports = {
-  scan
+const getItem = require('./dynamodb/get-item');
+
+const client = new DynamoDB({});
+const documentClient = DynamoDBDocument.from(client);
+
+const dynamoClient = {
+  getItem: (tableName, key) => getItem(documentClient, tableName, key)
 };
+
+module.exports = dynamoClient;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mhlabs/dynamodb-client",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@mhlabs/dynamodb-client",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.51.0",
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@types/jest": "^27.4.0",
+        "aws-sdk-client-mock": "^0.6.0",
         "eslint": "^8.7.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-config-prettier": "^8.3.0",
@@ -35,6 +36,25 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
+      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "2.0.0",
@@ -124,6 +144,27 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/chunked-blob-reader": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.52.0.tgz",
+      "integrity": "sha512-BAZhriHHfvnGOd0P9xcnGu8DGyxOa0lgmEw+Tc6nZpXJzx0P+1Sd76q5gE5d/IZ0r5VTB6rfwwKUoG6iShNCwQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/chunked-blob-reader-native": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.52.0.tgz",
+      "integrity": "sha512-/hVzC0Q12/mWRMBBQD3v82xsLSxZ4RwG6N44XP7MuJoHy4ui4T7D9RSuvBpzzr/4fqF0w9M7XYv6aM4BD2pFIQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/util-base64-browser": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
     "node_modules/@aws-sdk/client-dynamodb": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.52.0.tgz",
@@ -165,6 +206,67 @@
         "@aws-sdk/util-waiter": "3.52.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.52.0.tgz",
+      "integrity": "sha512-QTY12zuKqWbtLG1H2RV13JG+NFNDeDAR2Ffka/qNHU6NMUqyQnyf/1h2UCVIekTmSaR6L6bYGgHl//kxMSUwCw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.52.0",
+        "@aws-sdk/config-resolver": "3.52.0",
+        "@aws-sdk/credential-provider-node": "3.52.0",
+        "@aws-sdk/eventstream-serde-browser": "3.52.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.52.0",
+        "@aws-sdk/eventstream-serde-node": "3.52.0",
+        "@aws-sdk/fetch-http-handler": "3.52.0",
+        "@aws-sdk/hash-blob-browser": "3.52.0",
+        "@aws-sdk/hash-node": "3.52.0",
+        "@aws-sdk/hash-stream-node": "3.52.0",
+        "@aws-sdk/invalid-dependency": "3.52.0",
+        "@aws-sdk/md5-js": "3.52.0",
+        "@aws-sdk/middleware-apply-body-checksum": "3.52.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.52.0",
+        "@aws-sdk/middleware-content-length": "3.52.0",
+        "@aws-sdk/middleware-expect-continue": "3.52.0",
+        "@aws-sdk/middleware-host-header": "3.52.0",
+        "@aws-sdk/middleware-location-constraint": "3.52.0",
+        "@aws-sdk/middleware-logger": "3.52.0",
+        "@aws-sdk/middleware-retry": "3.52.0",
+        "@aws-sdk/middleware-sdk-s3": "3.52.0",
+        "@aws-sdk/middleware-serde": "3.52.0",
+        "@aws-sdk/middleware-signing": "3.52.0",
+        "@aws-sdk/middleware-ssec": "3.52.0",
+        "@aws-sdk/middleware-stack": "3.52.0",
+        "@aws-sdk/middleware-user-agent": "3.52.0",
+        "@aws-sdk/node-config-provider": "3.52.0",
+        "@aws-sdk/node-http-handler": "3.52.0",
+        "@aws-sdk/protocol-http": "3.52.0",
+        "@aws-sdk/smithy-client": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/url-parser": "3.52.0",
+        "@aws-sdk/util-base64-browser": "3.52.0",
+        "@aws-sdk/util-base64-node": "3.52.0",
+        "@aws-sdk/util-body-length-browser": "3.52.0",
+        "@aws-sdk/util-body-length-node": "3.52.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.52.0",
+        "@aws-sdk/util-defaults-mode-node": "3.52.0",
+        "@aws-sdk/util-user-agent-browser": "3.52.0",
+        "@aws-sdk/util-user-agent-node": "3.52.0",
+        "@aws-sdk/util-utf8-browser": "3.52.0",
+        "@aws-sdk/util-utf8-node": "3.52.0",
+        "@aws-sdk/util-waiter": "3.52.0",
+        "@aws-sdk/xml-builder": "3.52.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -393,6 +495,80 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/eventstream-marshaller": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.52.0.tgz",
+      "integrity": "sha512-RK5uWIOwae3Yzog8og3+e+k8kpRnjrg9hhOLmq2xG4m5seo7v7S5jfmb0uLX/Uqgd1vWMK5wKFJsdGhnAqykcQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/util-hex-encoding": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-browser": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.52.0.tgz",
+      "integrity": "sha512-Lo1RzjOCvOGDoyq1hdxO7YWsdyc5ZMo0+jf/SDm64ZM8jE4eRUh1iGj0kCOKIIr/tCbzhbvP4SoNDfehJ2rqfA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/eventstream-marshaller": "3.52.0",
+        "@aws-sdk/eventstream-serde-universal": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.52.0.tgz",
+      "integrity": "sha512-yCfYf2MepHPpRTsbGNNLVDbN22woSmNDM2bEeK5gDbyV23MGlnLxjekLKdBbH5M6FUqfMbpsM60gDgJgas3ovA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-node": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.52.0.tgz",
+      "integrity": "sha512-hL067bWZ875oL+l+Q1Wrhkq/V9727fHeJ1J4Kr/o84hGRnIkN7OiNDLIMyUTrGdc0I4diGUbc8FVJiRtZRmphw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/eventstream-marshaller": "3.52.0",
+        "@aws-sdk/eventstream-serde-universal": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/eventstream-serde-universal": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.52.0.tgz",
+      "integrity": "sha512-CDMcBJDNDJfGWz2Vk2p1Ef6JbZDVZVZDG8F7Gdhn7RsiMsFf7QiF4vcNEJwQIX25ZSerRqEitBT8nEZEDxEYGw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/eventstream-marshaller": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/fetch-http-handler": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.52.0.tgz",
@@ -405,6 +581,19 @@
         "tslib": "^2.3.0"
       }
     },
+    "node_modules/@aws-sdk/hash-blob-browser": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.52.0.tgz",
+      "integrity": "sha512-EhEXgO/cb67EHXl/F1D3vtdv695n1nIrAQLdiTOcNvdMRWLpjb2MkR3GI9tppkTabF4o3allgZVebKVeqINSMQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/chunked-blob-reader": "3.52.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
     "node_modules/@aws-sdk/hash-node": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.52.0.tgz",
@@ -412,6 +601,20 @@
       "dependencies": {
         "@aws-sdk/types": "3.52.0",
         "@aws-sdk/util-buffer-from": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/hash-stream-node": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.52.0.tgz",
+      "integrity": "sha512-Khgy6DM2Kpcqbom8dYQtH7GmxnprdQVHsKvhmkReqfksxvrwNwo+S2RCDlceGTVIkELuvyfnVd19JLQO7BnqTw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -455,6 +658,52 @@
         "@aws-sdk/types": "^3.0.0"
       }
     },
+    "node_modules/@aws-sdk/md5-js": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.52.0.tgz",
+      "integrity": "sha512-M0oHeBDvXCapQvvGzzlMrkW1vRfExngB/Gn93Vmdpt97+ieHkfHgo9fU/erQKb+HwnlZbhVJW3vEgfHPLvql6A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/util-utf8-browser": "3.52.0",
+        "@aws-sdk/util-utf8-node": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-apply-body-checksum": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.52.0.tgz",
+      "integrity": "sha512-f5ynflavshbkmV4ZpcwW2WoYAP69bOpv8bUPNsiKEzL07q6ZperkIaYre9BajNMxGN+UNSoE5CQIvRGcwC6UxA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.52.0",
+        "@aws-sdk/protocol-http": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.52.0.tgz",
+      "integrity": "sha512-KOq8kTzhWYiwits89pnCduL7ojijthfFR5PRvLW6IwQbPxIg/AjdO5gYbMUTLaVAO1b7LoI3ztk+lmLQ2yvjOA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/util-arn-parser": "3.52.0",
+        "@aws-sdk/util-config-provider": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-content-length": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.52.0.tgz",
@@ -483,12 +732,57 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.52.0.tgz",
+      "integrity": "sha512-1rpD1I/HwDdVAW9wBtLv34gxrfkfLEyTEj2Y/1Qh/62rMX7KbBT0CmbbO33upOqyrsJDW961Mu/d5cVZW1N3XQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/middleware-header-default": "3.52.0",
+        "@aws-sdk/protocol-http": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-header-default": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.52.0.tgz",
+      "integrity": "sha512-ts5kuAnLjC9HW9W/vkCrlMa4a5DG45BkOjhYhD4YZCDBt9+E/N5Pt/14jmTdTO5LQ26zVC6Z3ByBXXayDKEIow==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.52.0.tgz",
       "integrity": "sha512-t7y0gtJyFNrS6bwluR7N2LtppA7B0SDk+uNlvOJOYnJRms89fXltyMJWl8wrv8IHHvrhRLwNEP22vvOhn3hriA==",
       "dependencies": {
         "@aws-sdk/protocol-http": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.52.0.tgz",
+      "integrity": "sha512-P+RfKVXL6X+vu7e54vu73TNje15y+Jo1VEbBpFGz5wYsLlBO58e6utDYLOYLwj+WzLqShSzZX9ejZzxrOSYQdQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
       },
@@ -521,6 +815,26 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.52.0.tgz",
+      "integrity": "sha512-M9ivvdTEPFoFUgfGLdFeRxFGRh/Edq6tevSnWjdOoLTgbzq8tnuKkj9v3gKsIN+a1QWP6Ef0ThH/jyuFDcBEnQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.52.0",
+        "@aws-sdk/signature-v4": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/util-arn-parser": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/signature-v4-crt": "^3.31.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
@@ -559,6 +873,20 @@
         "@aws-sdk/property-provider": "3.52.0",
         "@aws-sdk/protocol-http": "3.52.0",
         "@aws-sdk/signature-v4": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.52.0.tgz",
+      "integrity": "sha512-lEswW+Hf5tvkPs6aNRbPF5/Iizh62lq4NK6bZjvQF6kqyUoIGhOehQOZMmTm6jw0058KVhrzNIKipBpi7LuF6w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
       },
@@ -702,6 +1030,25 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/@aws-sdk/signature-v4-crt": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.52.0.tgz",
+      "integrity": "sha512-+9b8WDHxCJ9OoXWMhV91Xt2nQtjqYatR2NA+gUUHjOiHbSSY0nG0jMsgKQU7MP6OAEWpZnRWEpeZtwwJm+gatg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.52.0",
+        "@aws-sdk/querystring-parser": "3.52.0",
+        "@aws-sdk/signature-v4": "3.52.0",
+        "@aws-sdk/util-hex-encoding": "3.52.0",
+        "@aws-sdk/util-uri-escape": "3.52.0",
+        "aws-crt": "^1.9.7",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/@aws-sdk/smithy-client": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.52.0.tgz",
@@ -731,6 +1078,19 @@
         "@aws-sdk/querystring-parser": "3.52.0",
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.52.0.tgz",
+      "integrity": "sha512-mMsoYJ70+BGkVpdfQbu942v4fAGzx+pIL8+QnQhzUmcU0HbNkI0vYliMWfzz7ka9CHgbijUI/ANKA319zgKtvA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/util-base64-browser": {
@@ -931,6 +1291,19 @@
       "dependencies": {
         "@aws-sdk/abort-controller": "3.52.0",
         "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.52.0.tgz",
+      "integrity": "sha512-GMdcxdwDZuIMlGnewdB48bpj8eqA3nubs3biy6vRFX8zhv8OqD+m5fMinoEwD8/MGqWE3WD7VZlbbdwYtNVWzQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -1526,6 +1899,23 @@
         "node": ">= 4"
       }
     },
+    "node_modules/@httptoolkit/websocket-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@httptoolkit/websocket-stream/-/websocket-stream-6.0.0.tgz",
+      "integrity": "sha512-EC8m9JbhpGX2okfvLakqrmy4Le0VyNKR7b3IdvFZR/BfFO4ruh/XceBvXhCFHkykchnFxuOSlRwFiqNSXlwcGA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/ws": "*",
+        "duplexify": "^3.5.1",
+        "inherits": "^2.0.1",
+        "isomorphic-ws": "^4.0.1",
+        "readable-stream": "^2.3.3",
+        "safe-buffer": "^5.1.2",
+        "ws": "*",
+        "xtend": "^4.0.0"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
@@ -1990,6 +2380,23 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "node_modules/@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -2107,11 +2514,39 @@
       "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
       "dev": true
     },
+    "node_modules/@types/sinon": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.10.tgz",
+      "integrity": "sha512-US5E539UfeL2DiWALzCyk0c4zKh6sCv86V/0lpda/afMJJ0oEm2SrKgedH5optvFWstnJ8e1MNYhLmPhAy4rvQ==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/fake-timers": "^7.1.0"
+      }
+    },
+    "node_modules/@types/sinon/node_modules/@sinonjs/fake-timers": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-ahRJZquUYCdOZf/rCsWg88S0/+cb9wazUBHv6HZEe3XdYaBe2zr/slM8J28X07Hn88Pnm4ezo7N8/ofnOgrPVQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -2349,6 +2784,13 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -2413,6 +2855,17 @@
         "node": ">= 8"
       }
     },
+    "node_modules/are-we-there-yet": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+      "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.0 || ^1.1.13"
+      }
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2469,6 +2922,49 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "node_modules/aws-crt": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.11.0.tgz",
+      "integrity": "sha512-qIBDRLOKRFuPTjkOAt3Al5zbcR6YyjfEl3TUc0R/xZ64aDxWGGXDStfDpkGCLSgV7jH+o7KQ47U9PM3URiFNFg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "@httptoolkit/websocket-stream": "^6.0.0",
+        "axios": "^0.24.0",
+        "cmake-js": "6.3.0",
+        "crypto-js": "^4.0.0",
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "mqtt": "^4.3.4",
+        "tar": "^6.1.11",
+        "ws": "^7.5.5"
+      }
+    },
+    "node_modules/aws-sdk-client-mock": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-0.6.0.tgz",
+      "integrity": "sha512-VCIvPD8ue5+bLQW31cyDim4xtS7Ks5TJ1p1Gug1TBxPqX2gJE/uEe0Y3o368DLODn7/mGArWYg6QjacXOe5BGw==",
+      "dev": true,
+      "dependencies": {
+        "@types/sinon": "10.0.10",
+        "sinon": "^11.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-s3": "^3.0.0",
+        "@aws-sdk/types": "^3.0.0"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
     },
     "node_modules/babel-jest": {
       "version": "27.5.1",
@@ -2568,6 +3064,85 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -2633,11 +3208,63 @@
         "node-int64": "^0.4.0"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.2.0"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.2",
@@ -2680,6 +3307,19 @@
         "url": "https://opencollective.com/browserslist"
       }
     },
+    "node_modules/chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "traverse": ">=0.3.0 <0.4"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2701,6 +3341,16 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -2728,6 +3378,277 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "node_modules/cmake-js": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.3.0.tgz",
+      "integrity": "sha512-1uqTOmFt6BIqKlrX+39/aewU/JVhyZWDqwAL+6psToUwxj3yWPJiwxiZFmV0XdcoWmqGs7peZTxTbJtAcH8hxw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "axios": "^0.21.1",
+        "debug": "^4",
+        "fs-extra": "^5.0.0",
+        "is-iojs": "^1.0.1",
+        "lodash": "^4",
+        "memory-stream": "0",
+        "npmlog": "^1.2.0",
+        "rc": "^1.2.7",
+        "semver": "^5.0.3",
+        "splitargs": "0",
+        "tar": "^4",
+        "unzipper": "^0.8.13",
+        "url-join": "0",
+        "which": "^1.0.9",
+        "yargs": "^3.6.0"
+      },
+      "bin": {
+        "cmake-js": "bin/cmake-js"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/camelcase": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/cmake-js/node_modules/cliui": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/fs-minipass": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+      "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "minipass": "^2.6.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/minipass": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+      "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "^5.1.2",
+        "yallist": "^3.0.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/minizlib": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+      "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "minipass": "^2.9.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/cmake-js/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
+    },
+    "node_modules/cmake-js/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/cmake-js/node_modules/string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/tar": {
+      "version": "4.4.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+      "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "chownr": "^1.1.4",
+        "fs-minipass": "^1.2.7",
+        "minipass": "^2.9.0",
+        "minizlib": "^1.3.3",
+        "mkdirp": "^0.5.5",
+        "safe-buffer": "^5.2.1",
+        "yallist": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=4.5"
+      }
+    },
+    "node_modules/cmake-js/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/cmake-js/node_modules/wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cmake-js/node_modules/y18n": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+      "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/cmake-js/node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/cmake-js/node_modules/yargs": {
+      "version": "3.32.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "camelcase": "^2.0.1",
+        "cliui": "^3.0.3",
+        "decamelize": "^1.1.1",
+        "os-locale": "^1.4.0",
+        "string-width": "^1.0.1",
+        "window-size": "^0.1.4",
+        "y18n": "^3.2.0"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2736,6 +3657,16 @@
       "engines": {
         "iojs": ">= 1.0.0",
         "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -2774,11 +3705,63 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
+      "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "leven": "^2.1.0",
+        "minimist": "^1.1.0"
+      }
+    },
+    "node_modules/commist/node_modules/leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "engines": [
+        "node >= 6.0"
+      ],
+      "peer": true,
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/confusing-browser-globals": {
       "version": "1.0.11",
@@ -2795,6 +3778,13 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2808,6 +3798,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/cssom": {
       "version": "0.4.4",
@@ -2864,6 +3861,16 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
@@ -2875,6 +3882,16 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=4.0.0"
+      }
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2912,6 +3929,13 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -2919,6 +3943,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
       }
     },
     "node_modules/diff-sequences": {
@@ -2975,6 +4008,29 @@
         "node": ">=8"
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.71",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
@@ -2998,6 +4054,16 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/entities": {
       "version": "2.2.0",
@@ -3613,6 +4679,13 @@
         "url": "https://paypal.me/naturalintelligence"
       }
     },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -3686,6 +4759,27 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/form-data": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -3698,6 +4792,31 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/fs.realpath": {
@@ -3720,6 +4839,48 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/fstream/node_modules/mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "minimist": "^1.2.5"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
+    "node_modules/fstream/node_modules/rimraf": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+      "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -3731,6 +4892,20 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "node_modules/gauge": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+      "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi": "^0.3.0",
+        "has-unicode": "^2.0.0",
+        "lodash.pad": "^4.1.0",
+        "lodash.padend": "^4.1.0",
+        "lodash.padstart": "^4.1.0"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -3931,6 +5106,39 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/help-me": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
+      "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.6",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/help-me/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -3996,6 +5204,27 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "peer": true
     },
     "node_modules/ignore": {
       "version": "5.2.0",
@@ -4066,6 +5295,13 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -4078,6 +5314,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-arrayish": {
@@ -4191,6 +5437,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-iojs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
+      "integrity": "sha1-TBEDO11dlNbqs3dd7cm+fQCDJfE=",
+      "dev": true,
+      "peer": true
     },
     "node_modules/is-negative-zero": {
       "version": "2.0.2",
@@ -4319,11 +5572,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "dev": true,
+      "peer": true,
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -5019,6 +6289,13 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/js-sdsl": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
+      "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -5128,6 +6405,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "peer": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -5135,6 +6428,19 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "invert-kv": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/leven": {
@@ -5165,6 +6471,13 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "node_modules/listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -5184,11 +6497,38 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "node_modules/lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.pad": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lodash.padend": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/lodash.padstart": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
+      "dev": true,
+      "peer": true
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -5225,6 +6565,43 @@
       "dependencies": {
         "tmpl": "1.0.5"
       }
+    },
+    "node_modules/memory-stream": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
+      "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "~1.0.26-2"
+      }
+    },
+    "node_modules/memory-stream/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/memory-stream/node_modules/readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/memory-stream/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true,
+      "peer": true
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -5302,12 +6679,126 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "node_modules/minipass": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/mnemonist": {
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
       "dependencies": {
         "obliterator": "^1.6.1"
+      }
+    },
+    "node_modules/mqtt": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.6.tgz",
+      "integrity": "sha512-1dgQbkbh1Bba9iAGDNIrhSZ4nLDjbhmNHjOEvsmKI1Bb+2orj0gHwjqUKJ5CKUMKBYbkQYRM1fy+N1/2iZOj5w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "commist": "^1.0.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.1.1",
+        "duplexify": "^4.1.1",
+        "help-me": "^3.0.0",
+        "inherits": "^2.0.3",
+        "lru-cache": "^6.0.0",
+        "minimist": "^1.2.5",
+        "mqtt-packet": "^6.8.0",
+        "number-allocator": "^1.0.9",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "reinterval": "^1.1.0",
+        "rfdc": "^1.3.0",
+        "split2": "^3.1.0",
+        "ws": "^7.5.5",
+        "xtend": "^4.0.2"
+      },
+      "bin": {
+        "mqtt": "bin/mqtt.js",
+        "mqtt_pub": "bin/pub.js",
+        "mqtt_sub": "bin/sub.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/mqtt-packet": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
+      "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "bl": "^4.0.2",
+        "debug": "^4.1.1",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/mqtt/node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
+    "node_modules/mqtt/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/ms": {
@@ -5321,6 +6812,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -5353,6 +6857,39 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+      "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "ansi": "~0.3.0",
+        "are-we-there-yet": "~1.0.0",
+        "gauge": "~1.2.0"
+      }
+    },
+    "node_modules/number-allocator": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.9.tgz",
+      "integrity": "sha512-sIIF0dZKMs3roPUD7rLreH8H3x47QKV9dHZ+PeSnH24gL0CxKxz/823woGZC0hLBSb2Ar/rOOeHiNbnPBum/Mw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.3.1",
+        "js-sdsl": "^2.1.2"
+      }
+    },
+    "node_modules/number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/nwsapi": {
@@ -5474,6 +7011,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "lcid": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -5574,6 +7124,21 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true
+    },
+    "node_modules/path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "dependencies": {
+        "isarray": "0.0.1"
+      }
+    },
+    "node_modules/path-to-regexp/node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
       "dev": true
     },
     "node_modules/path-type": {
@@ -5753,6 +7318,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -5771,6 +7343,17 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -5801,11 +7384,53 @@
         }
       ]
     },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
     },
     "node_modules/regexpp": {
       "version": "3.2.0",
@@ -5818,6 +7443,13 @@
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
       }
+    },
+    "node_modules/reinterval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+      "integrity": "sha1-M2Hs+jymwYKDOA3Qu5VG85D17Oc=",
+      "dev": true,
+      "peer": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -5894,6 +7526,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -5965,6 +7604,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6006,6 +7652,33 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "node_modules/sinon": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^7.1.2",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/sinon"
+      }
+    },
+    "node_modules/sinon/node_modules/@sinonjs/fake-timers": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+      "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+      "dev": true,
+      "dependencies": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -6040,6 +7713,38 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^3.0.0"
+      }
+    },
+    "node_modules/split2/node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/splitargs": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
+      "integrity": "sha1-/p965lc3GzOxDLgNoUPPgknPazs=",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6065,6 +7770,23 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string-length": {
@@ -6205,6 +7927,24 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "node_modules/tar": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -6300,6 +8040,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
@@ -6392,6 +8142,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -6439,6 +8196,54 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/unzipper": {
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
+      "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "~1.0.10",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.1.5",
+        "setimmediate": "~1.0.4"
+      }
+    },
+    "node_modules/unzipper/node_modules/process-nextick-args": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/unzipper/node_modules/readable-stream": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+      "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "buffer-shims": "^1.0.0",
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~1.0.6",
+        "string_decoder": "~0.10.x",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/unzipper/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -6447,6 +8252,20 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-join": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g=",
+      "dev": true,
+      "peer": true
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true,
+      "peer": true
     },
     "node_modules/uuid": {
       "version": "8.3.2",
@@ -6584,6 +8403,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "dev": true,
+      "peer": true,
+      "bin": {
+        "window-size": "cli.js"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -6661,6 +8493,16 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
     },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -6712,6 +8554,27 @@
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
+      }
+    },
+    "@aws-crypto/crc32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
+      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "@aws-crypto/ie11-detection": {
@@ -6809,6 +8672,27 @@
         "tslib": "^2.3.0"
       }
     },
+    "@aws-sdk/chunked-blob-reader": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.52.0.tgz",
+      "integrity": "sha512-BAZhriHHfvnGOd0P9xcnGu8DGyxOa0lgmEw+Tc6nZpXJzx0P+1Sd76q5gE5d/IZ0r5VTB6rfwwKUoG6iShNCwQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/chunked-blob-reader-native": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.52.0.tgz",
+      "integrity": "sha512-/hVzC0Q12/mWRMBBQD3v82xsLSxZ4RwG6N44XP7MuJoHy4ui4T7D9RSuvBpzzr/4fqF0w9M7XYv6aM4BD2pFIQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/util-base64-browser": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
     "@aws-sdk/client-dynamodb": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.52.0.tgz",
@@ -6850,6 +8734,64 @@
         "@aws-sdk/util-waiter": "3.52.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.52.0.tgz",
+      "integrity": "sha512-QTY12zuKqWbtLG1H2RV13JG+NFNDeDAR2Ffka/qNHU6NMUqyQnyf/1h2UCVIekTmSaR6L6bYGgHl//kxMSUwCw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.52.0",
+        "@aws-sdk/config-resolver": "3.52.0",
+        "@aws-sdk/credential-provider-node": "3.52.0",
+        "@aws-sdk/eventstream-serde-browser": "3.52.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.52.0",
+        "@aws-sdk/eventstream-serde-node": "3.52.0",
+        "@aws-sdk/fetch-http-handler": "3.52.0",
+        "@aws-sdk/hash-blob-browser": "3.52.0",
+        "@aws-sdk/hash-node": "3.52.0",
+        "@aws-sdk/hash-stream-node": "3.52.0",
+        "@aws-sdk/invalid-dependency": "3.52.0",
+        "@aws-sdk/md5-js": "3.52.0",
+        "@aws-sdk/middleware-apply-body-checksum": "3.52.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.52.0",
+        "@aws-sdk/middleware-content-length": "3.52.0",
+        "@aws-sdk/middleware-expect-continue": "3.52.0",
+        "@aws-sdk/middleware-host-header": "3.52.0",
+        "@aws-sdk/middleware-location-constraint": "3.52.0",
+        "@aws-sdk/middleware-logger": "3.52.0",
+        "@aws-sdk/middleware-retry": "3.52.0",
+        "@aws-sdk/middleware-sdk-s3": "3.52.0",
+        "@aws-sdk/middleware-serde": "3.52.0",
+        "@aws-sdk/middleware-signing": "3.52.0",
+        "@aws-sdk/middleware-ssec": "3.52.0",
+        "@aws-sdk/middleware-stack": "3.52.0",
+        "@aws-sdk/middleware-user-agent": "3.52.0",
+        "@aws-sdk/node-config-provider": "3.52.0",
+        "@aws-sdk/node-http-handler": "3.52.0",
+        "@aws-sdk/protocol-http": "3.52.0",
+        "@aws-sdk/smithy-client": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/url-parser": "3.52.0",
+        "@aws-sdk/util-base64-browser": "3.52.0",
+        "@aws-sdk/util-base64-node": "3.52.0",
+        "@aws-sdk/util-body-length-browser": "3.52.0",
+        "@aws-sdk/util-body-length-node": "3.52.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.52.0",
+        "@aws-sdk/util-defaults-mode-node": "3.52.0",
+        "@aws-sdk/util-user-agent-browser": "3.52.0",
+        "@aws-sdk/util-user-agent-node": "3.52.0",
+        "@aws-sdk/util-utf8-browser": "3.52.0",
+        "@aws-sdk/util-utf8-node": "3.52.0",
+        "@aws-sdk/util-waiter": "3.52.0",
+        "@aws-sdk/xml-builder": "3.52.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/client-sso": {
@@ -7042,6 +8984,68 @@
         "tslib": "^2.3.0"
       }
     },
+    "@aws-sdk/eventstream-marshaller": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-marshaller/-/eventstream-marshaller-3.52.0.tgz",
+      "integrity": "sha512-RK5uWIOwae3Yzog8og3+e+k8kpRnjrg9hhOLmq2xG4m5seo7v7S5jfmb0uLX/Uqgd1vWMK5wKFJsdGhnAqykcQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/util-hex-encoding": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-browser": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.52.0.tgz",
+      "integrity": "sha512-Lo1RzjOCvOGDoyq1hdxO7YWsdyc5ZMo0+jf/SDm64ZM8jE4eRUh1iGj0kCOKIIr/tCbzhbvP4SoNDfehJ2rqfA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.52.0",
+        "@aws-sdk/eventstream-serde-universal": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.52.0.tgz",
+      "integrity": "sha512-yCfYf2MepHPpRTsbGNNLVDbN22woSmNDM2bEeK5gDbyV23MGlnLxjekLKdBbH5M6FUqfMbpsM60gDgJgas3ovA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-node": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.52.0.tgz",
+      "integrity": "sha512-hL067bWZ875oL+l+Q1Wrhkq/V9727fHeJ1J4Kr/o84hGRnIkN7OiNDLIMyUTrGdc0I4diGUbc8FVJiRtZRmphw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.52.0",
+        "@aws-sdk/eventstream-serde-universal": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/eventstream-serde-universal": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.52.0.tgz",
+      "integrity": "sha512-CDMcBJDNDJfGWz2Vk2p1Ef6JbZDVZVZDG8F7Gdhn7RsiMsFf7QiF4vcNEJwQIX25ZSerRqEitBT8nEZEDxEYGw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/eventstream-marshaller": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
     "@aws-sdk/fetch-http-handler": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.52.0.tgz",
@@ -7054,6 +9058,19 @@
         "tslib": "^2.3.0"
       }
     },
+    "@aws-sdk/hash-blob-browser": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.52.0.tgz",
+      "integrity": "sha512-EhEXgO/cb67EHXl/F1D3vtdv695n1nIrAQLdiTOcNvdMRWLpjb2MkR3GI9tppkTabF4o3allgZVebKVeqINSMQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/chunked-blob-reader": "3.52.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
     "@aws-sdk/hash-node": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.52.0.tgz",
@@ -7061,6 +9078,17 @@
       "requires": {
         "@aws-sdk/types": "3.52.0",
         "@aws-sdk/util-buffer-from": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/hash-stream-node": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.52.0.tgz",
+      "integrity": "sha512-Khgy6DM2Kpcqbom8dYQtH7GmxnprdQVHsKvhmkReqfksxvrwNwo+S2RCDlceGTVIkELuvyfnVd19JLQO7BnqTw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
       }
     },
@@ -7090,6 +9118,46 @@
         "tslib": "^2.3.0"
       }
     },
+    "@aws-sdk/md5-js": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.52.0.tgz",
+      "integrity": "sha512-M0oHeBDvXCapQvvGzzlMrkW1vRfExngB/Gn93Vmdpt97+ieHkfHgo9fU/erQKb+HwnlZbhVJW3vEgfHPLvql6A==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/util-utf8-browser": "3.52.0",
+        "@aws-sdk/util-utf8-node": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-apply-body-checksum": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-apply-body-checksum/-/middleware-apply-body-checksum-3.52.0.tgz",
+      "integrity": "sha512-f5ynflavshbkmV4ZpcwW2WoYAP69bOpv8bUPNsiKEzL07q6ZperkIaYre9BajNMxGN+UNSoE5CQIvRGcwC6UxA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.52.0",
+        "@aws-sdk/protocol-http": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.52.0.tgz",
+      "integrity": "sha512-KOq8kTzhWYiwits89pnCduL7ojijthfFR5PRvLW6IwQbPxIg/AjdO5gYbMUTLaVAO1b7LoI3ztk+lmLQ2yvjOA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/util-arn-parser": "3.52.0",
+        "@aws-sdk/util-config-provider": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
     "@aws-sdk/middleware-content-length": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.52.0.tgz",
@@ -7112,12 +9180,48 @@
         "tslib": "^2.3.0"
       }
     },
+    "@aws-sdk/middleware-expect-continue": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.52.0.tgz",
+      "integrity": "sha512-1rpD1I/HwDdVAW9wBtLv34gxrfkfLEyTEj2Y/1Qh/62rMX7KbBT0CmbbO33upOqyrsJDW961Mu/d5cVZW1N3XQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/middleware-header-default": "3.52.0",
+        "@aws-sdk/protocol-http": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-header-default": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-header-default/-/middleware-header-default-3.52.0.tgz",
+      "integrity": "sha512-ts5kuAnLjC9HW9W/vkCrlMa4a5DG45BkOjhYhD4YZCDBt9+E/N5Pt/14jmTdTO5LQ26zVC6Z3ByBXXayDKEIow==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
     "@aws-sdk/middleware-host-header": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.52.0.tgz",
       "integrity": "sha512-t7y0gtJyFNrS6bwluR7N2LtppA7B0SDk+uNlvOJOYnJRms89fXltyMJWl8wrv8IHHvrhRLwNEP22vvOhn3hriA==",
       "requires": {
         "@aws-sdk/protocol-http": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-location-constraint": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.52.0.tgz",
+      "integrity": "sha512-P+RfKVXL6X+vu7e54vu73TNje15y+Jo1VEbBpFGz5wYsLlBO58e6utDYLOYLwj+WzLqShSzZX9ejZzxrOSYQdQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
       }
@@ -7141,6 +9245,20 @@
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.52.0.tgz",
+      "integrity": "sha512-M9ivvdTEPFoFUgfGLdFeRxFGRh/Edq6tevSnWjdOoLTgbzq8tnuKkj9v3gKsIN+a1QWP6Ef0ThH/jyuFDcBEnQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.52.0",
+        "@aws-sdk/signature-v4": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/util-arn-parser": "3.52.0",
+        "tslib": "^2.3.0"
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
@@ -7173,6 +9291,17 @@
         "@aws-sdk/property-provider": "3.52.0",
         "@aws-sdk/protocol-http": "3.52.0",
         "@aws-sdk/signature-v4": "3.52.0",
+        "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/middleware-ssec": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.52.0.tgz",
+      "integrity": "sha512-lEswW+Hf5tvkPs6aNRbPF5/Iizh62lq4NK6bZjvQF6kqyUoIGhOehQOZMmTm6jw0058KVhrzNIKipBpi7LuF6w==",
+      "dev": true,
+      "peer": true,
+      "requires": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
       }
@@ -7280,6 +9409,22 @@
         "tslib": "^2.3.0"
       }
     },
+    "@aws-sdk/signature-v4-crt": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.52.0.tgz",
+      "integrity": "sha512-+9b8WDHxCJ9OoXWMhV91Xt2nQtjqYatR2NA+gUUHjOiHbSSY0nG0jMsgKQU7MP6OAEWpZnRWEpeZtwwJm+gatg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.52.0",
+        "@aws-sdk/querystring-parser": "3.52.0",
+        "@aws-sdk/signature-v4": "3.52.0",
+        "@aws-sdk/util-hex-encoding": "3.52.0",
+        "@aws-sdk/util-uri-escape": "3.52.0",
+        "aws-crt": "^1.9.7",
+        "tslib": "^2.3.0"
+      }
+    },
     "@aws-sdk/smithy-client": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.52.0.tgz",
@@ -7302,6 +9447,16 @@
       "requires": {
         "@aws-sdk/querystring-parser": "3.52.0",
         "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/util-arn-parser": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.52.0.tgz",
+      "integrity": "sha512-mMsoYJ70+BGkVpdfQbu942v4fAGzx+pIL8+QnQhzUmcU0HbNkI0vYliMWfzz7ka9CHgbijUI/ANKA319zgKtvA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
         "tslib": "^2.3.0"
       }
     },
@@ -7464,6 +9619,16 @@
       "requires": {
         "@aws-sdk/abort-controller": "3.52.0",
         "@aws-sdk/types": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.52.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.52.0.tgz",
+      "integrity": "sha512-GMdcxdwDZuIMlGnewdB48bpj8eqA3nubs3biy6vRFX8zhv8OqD+m5fMinoEwD8/MGqWE3WD7VZlbbdwYtNVWzQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
         "tslib": "^2.3.0"
       }
     },
@@ -7916,6 +10081,23 @@
         }
       }
     },
+    "@httptoolkit/websocket-stream": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@httptoolkit/websocket-stream/-/websocket-stream-6.0.0.tgz",
+      "integrity": "sha512-EC8m9JbhpGX2okfvLakqrmy4Le0VyNKR7b3IdvFZR/BfFO4ruh/XceBvXhCFHkykchnFxuOSlRwFiqNSXlwcGA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@types/ws": "*",
+        "duplexify": "^3.5.1",
+        "inherits": "^2.0.1",
+        "isomorphic-ws": "^4.0.1",
+        "readable-stream": "^2.3.3",
+        "safe-buffer": "^5.1.2",
+        "ws": "*",
+        "xtend": "^4.0.0"
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.9.3.tgz",
@@ -8285,6 +10467,23 @@
         "@sinonjs/commons": "^1.7.0"
       }
     },
+    "@sinonjs/samsam": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-6.1.1.tgz",
+      "integrity": "sha512-cZ7rKJTLiE7u7Wi/v9Hc2fs3Ucc3jrWeMgPHbbTCeVAB2S0wOBbYlkJVeNSL04i7fdhT8wIbDq1zhC/PXTD2SA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -8399,11 +10598,41 @@
       "integrity": "sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==",
       "dev": true
     },
+    "@types/sinon": {
+      "version": "10.0.10",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.10.tgz",
+      "integrity": "sha512-US5E539UfeL2DiWALzCyk0c4zKh6sCv86V/0lpda/afMJJ0oEm2SrKgedH5optvFWstnJ8e1MNYhLmPhAy4rvQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/fake-timers": "^7.1.0"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+          "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        }
+      }
+    },
     "@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
       "dev": true
+    },
+    "@types/ws": {
+      "version": "8.2.3",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.3.tgz",
+      "integrity": "sha512-ahRJZquUYCdOZf/rCsWg88S0/+cb9wazUBHv6HZEe3XdYaBe2zr/slM8J28X07Hn88Pnm4ezo7N8/ofnOgrPVQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@types/node": "*"
+      }
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -8568,6 +10797,13 @@
         "uri-js": "^4.2.2"
       }
     },
+    "ansi": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+      "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+      "dev": true,
+      "peer": true
+    },
     "ansi-escapes": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
@@ -8608,6 +10844,17 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
+      }
+    },
+    "are-we-there-yet": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
+      "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.0 || ^1.1.13"
       }
     },
     "argparse": {
@@ -8651,6 +10898,44 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
+    },
+    "aws-crt": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.11.0.tgz",
+      "integrity": "sha512-qIBDRLOKRFuPTjkOAt3Al5zbcR6YyjfEl3TUc0R/xZ64aDxWGGXDStfDpkGCLSgV7jH+o7KQ47U9PM3URiFNFg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@httptoolkit/websocket-stream": "^6.0.0",
+        "axios": "^0.24.0",
+        "cmake-js": "6.3.0",
+        "crypto-js": "^4.0.0",
+        "fastestsmallesttextencoderdecoder": "^1.0.22",
+        "mqtt": "^4.3.4",
+        "tar": "^6.1.11",
+        "ws": "^7.5.5"
+      }
+    },
+    "aws-sdk-client-mock": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-0.6.0.tgz",
+      "integrity": "sha512-VCIvPD8ue5+bLQW31cyDim4xtS7Ks5TJ1p1Gug1TBxPqX2gJE/uEe0Y3o368DLODn7/mGArWYg6QjacXOe5BGw==",
+      "dev": true,
+      "requires": {
+        "@types/sinon": "10.0.10",
+        "sinon": "^11.1.1",
+        "tslib": "^2.1.0"
+      }
+    },
+    "axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "follow-redirects": "^1.14.4"
+      }
     },
     "babel-jest": {
       "version": "27.5.1",
@@ -8729,6 +11014,64 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "peer": true
+    },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "dev": true,
+      "peer": true
+    },
+    "binary": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
+      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "buffers": "~0.1.1",
+        "chainsaw": "~0.1.0"
+      }
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "bluebird": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
+      "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+      "dev": true,
+      "peer": true
+    },
     "bowser": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
@@ -8781,11 +11124,43 @@
         "node-int64": "^0.4.0"
       }
     },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "buffer-indexof-polyfill": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
+      "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+      "dev": true,
+      "peer": true
+    },
+    "buffer-shims": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+      "dev": true,
+      "peer": true
+    },
+    "buffers": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
+      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
+      "dev": true,
+      "peer": true
     },
     "call-bind": {
       "version": "1.0.2",
@@ -8815,6 +11190,16 @@
       "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
       "dev": true
     },
+    "chainsaw": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
+      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "traverse": ">=0.3.0 <0.4"
+      }
+    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -8830,6 +11215,13 @@
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
+    },
+    "chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "peer": true
     },
     "ci-info": {
       "version": "3.3.0",
@@ -8854,11 +11246,241 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "cmake-js": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.3.0.tgz",
+      "integrity": "sha512-1uqTOmFt6BIqKlrX+39/aewU/JVhyZWDqwAL+6psToUwxj3yWPJiwxiZFmV0XdcoWmqGs7peZTxTbJtAcH8hxw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "axios": "^0.21.1",
+        "debug": "^4",
+        "fs-extra": "^5.0.0",
+        "is-iojs": "^1.0.1",
+        "lodash": "^4",
+        "memory-stream": "0",
+        "npmlog": "^1.2.0",
+        "rc": "^1.2.7",
+        "semver": "^5.0.3",
+        "splitargs": "0",
+        "tar": "^4",
+        "unzipper": "^0.8.13",
+        "url-join": "0",
+        "which": "^1.0.9",
+        "yargs": "^3.6.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true,
+          "peer": true
+        },
+        "axios": {
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "follow-redirects": "^1.14.0"
+          }
+        },
+        "camelcase": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+          "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+          "dev": true,
+          "peer": true
+        },
+        "chownr": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+          "dev": true,
+          "peer": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          }
+        },
+        "fs-minipass": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "minipass": "^2.6.0"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "minipass": {
+          "version": "2.9.0",
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
+          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "safe-buffer": "^5.1.2",
+            "yallist": "^3.0.0"
+          }
+        },
+        "minizlib": {
+          "version": "1.3.3",
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "minipass": "^2.9.0"
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "dev": true,
+          "peer": true
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true,
+          "peer": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "tar": {
+          "version": "4.4.19",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
+          "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "chownr": "^1.1.4",
+            "fs-minipass": "^1.2.7",
+            "minipass": "^2.9.0",
+            "minizlib": "^1.3.3",
+            "mkdirp": "^0.5.5",
+            "safe-buffer": "^5.2.1",
+            "yallist": "^3.1.1"
+          }
+        },
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "y18n": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
+          "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
+          "dev": true,
+          "peer": true
+        },
+        "yallist": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "dev": true,
+          "peer": true
+        },
+        "yargs": {
+          "version": "3.32.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
+          "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "camelcase": "^2.0.1",
+            "cliui": "^3.0.3",
+            "decamelize": "^1.1.1",
+            "os-locale": "^1.4.0",
+            "string-width": "^1.0.1",
+            "window-size": "^0.1.4",
+            "y18n": "^3.2.0"
+          }
+        }
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
       "dev": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true,
+      "peer": true
     },
     "collect-v8-coverage": {
       "version": "1.0.1",
@@ -8890,11 +11512,58 @@
         "delayed-stream": "~1.0.0"
       }
     },
+    "commist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
+      "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "leven": "^2.1.0",
+        "minimist": "^1.1.0"
+      },
+      "dependencies": {
+        "leven": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+          "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
     },
     "confusing-browser-globals": {
       "version": "1.0.11",
@@ -8911,6 +11580,13 @@
         "safe-buffer": "~5.1.1"
       }
     },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "peer": true
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -8921,6 +11597,13 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
+      "dev": true,
+      "peer": true
     },
     "cssom": {
       "version": "0.4.4",
@@ -8965,6 +11648,13 @@
         "ms": "2.1.2"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true,
+      "peer": true
+    },
     "decimal.js": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
@@ -8976,6 +11666,13 @@
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
       "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
       "dev": true
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "peer": true
     },
     "deep-is": {
       "version": "0.1.4",
@@ -9004,10 +11701,23 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "dev": true,
+      "peer": true
+    },
     "detect-newline": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "dev": true
+    },
+    "diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
       "dev": true
     },
     "diff-sequences": {
@@ -9051,6 +11761,29 @@
         }
       }
     },
+    "duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.71",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.71.tgz",
@@ -9068,6 +11801,16 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "entities": {
       "version": "2.2.0",
@@ -9525,6 +12268,13 @@
       "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-3.19.0.tgz",
       "integrity": "sha512-4pXwmBplsCPv8FOY1WRakF970TjNGnGnfbOnLqjlYvMiF1SR3yOHyxMR/YCXpPTOspNF5gwudqktIP4VsWkvBg=="
     },
+    "fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "dev": true,
+      "peer": true
+    },
     "fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -9586,6 +12336,13 @@
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
+      "dev": true,
+      "peer": true
+    },
     "form-data": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
@@ -9595,6 +12352,28 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
+      }
+    },
+    "fs-extra": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "minipass": "^3.0.0"
       }
     },
     "fs.realpath": {
@@ -9610,6 +12389,41 @@
       "dev": true,
       "optional": true
     },
+    "fstream": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
+      "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "inherits": "~2.0.0",
+        "mkdirp": ">=0.5 0",
+        "rimraf": "2"
+      },
+      "dependencies": {
+        "mkdirp": {
+          "version": "0.5.5",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "minimist": "^1.2.5"
+          }
+        },
+        "rimraf": {
+          "version": "2.7.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -9621,6 +12435,20 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "gauge": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
+      "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "ansi": "^0.3.0",
+        "has-unicode": "^2.0.0",
+        "lodash.pad": "^4.1.0",
+        "lodash.padend": "^4.1.0",
+        "lodash.padstart": "^4.1.0"
+      }
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -9755,6 +12583,38 @@
         "has-symbols": "^1.0.2"
       }
     },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "dev": true,
+      "peer": true
+    },
+    "help-me": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
+      "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "glob": "^7.1.6",
+        "readable-stream": "^3.6.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -9806,6 +12666,13 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "peer": true
+    },
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -9854,6 +12721,13 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "peer": true
+    },
     "internal-slot": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.3.tgz",
@@ -9864,6 +12738,13 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "dev": true,
+      "peer": true
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -9940,6 +12821,13 @@
       "requires": {
         "is-extglob": "^2.1.1"
       }
+    },
+    "is-iojs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
+      "integrity": "sha1-TBEDO11dlNbqs3dd7cm+fQCDJfE=",
+      "dev": true,
+      "peer": true
     },
     "is-negative-zero": {
       "version": "2.0.2",
@@ -10023,11 +12911,26 @@
         "call-bind": "^1.0.2"
       }
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true,
+      "peer": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "dev": true,
+      "peer": true,
+      "requires": {}
     },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -10570,6 +13473,13 @@
         }
       }
     },
+    "js-sdsl": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
+      "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A==",
+      "dev": true,
+      "peer": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -10653,11 +13563,37 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "just-extend": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
+      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
+      "dev": true
+    },
     "kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
     },
     "leven": {
       "version": "3.1.0",
@@ -10681,6 +13617,13 @@
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
     },
+    "listenercount": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
+      "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+      "dev": true,
+      "peer": true
+    },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
@@ -10697,11 +13640,38 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.pad": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
+      "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
+      "dev": true,
+      "peer": true
+    },
+    "lodash.padend": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
+      "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+      "dev": true,
+      "peer": true
+    },
+    "lodash.padstart": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
+      "dev": true,
+      "peer": true
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -10728,6 +13698,45 @@
       "dev": true,
       "requires": {
         "tmpl": "1.0.5"
+      }
+    },
+    "memory-stream": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
+      "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "readable-stream": "~1.0.26-2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true,
+          "peer": true
+        },
+        "readable-stream": {
+          "version": "1.0.34",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true,
+          "peer": true
+        }
       }
     },
     "merge-stream": {
@@ -10788,12 +13797,105 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
+    "minipass": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.6.tgz",
+      "integrity": "sha512-rty5kpw9/z8SX9dmxblFA6edItUmwJgMeYDZRrwlIVN27i8gysGbznJwUggw2V/FVqFSDdWy040ZPS811DYAqQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
+    },
+    "minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      }
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "peer": true
+    },
     "mnemonist": {
       "version": "0.38.3",
       "resolved": "https://registry.npmjs.org/mnemonist/-/mnemonist-0.38.3.tgz",
       "integrity": "sha512-2K9QYubXx/NAjv4VLq1d1Ly8pWNC5L3BrixtdkyTegXWJIqY+zLNDhhX/A+ZwWt70tB1S8H4BE8FLYEFyNoOBw==",
       "requires": {
         "obliterator": "^1.6.1"
+      }
+    },
+    "mqtt": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.6.tgz",
+      "integrity": "sha512-1dgQbkbh1Bba9iAGDNIrhSZ4nLDjbhmNHjOEvsmKI1Bb+2orj0gHwjqUKJ5CKUMKBYbkQYRM1fy+N1/2iZOj5w==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "commist": "^1.0.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.1.1",
+        "duplexify": "^4.1.1",
+        "help-me": "^3.0.0",
+        "inherits": "^2.0.3",
+        "lru-cache": "^6.0.0",
+        "minimist": "^1.2.5",
+        "mqtt-packet": "^6.8.0",
+        "number-allocator": "^1.0.9",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "reinterval": "^1.1.0",
+        "rfdc": "^1.3.0",
+        "split2": "^3.1.0",
+        "ws": "^7.5.5",
+        "xtend": "^4.0.2"
+      },
+      "dependencies": {
+        "duplexify": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+          "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "mqtt-packet": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
+      "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "bl": "^4.0.2",
+        "debug": "^4.1.1",
+        "process-nextick-args": "^2.0.1"
       }
     },
     "ms": {
@@ -10807,6 +13909,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "nise": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.1.tgz",
+      "integrity": "sha512-yr5kW2THW1AkxVmCnKEh4nbYkJdB3I7LUkiUgOvEkOp414mc2UMaHMA7pjq1nYowhdoJZGwEKGaQVbxfpWj10A==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": ">=5",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -10834,6 +13949,36 @@
       "requires": {
         "path-key": "^3.0.0"
       }
+    },
+    "npmlog": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
+      "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "ansi": "~0.3.0",
+        "are-we-there-yet": "~1.0.0",
+        "gauge": "~1.2.0"
+      }
+    },
+    "number-allocator": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.9.tgz",
+      "integrity": "sha512-sIIF0dZKMs3roPUD7rLreH8H3x47QKV9dHZ+PeSnH24gL0CxKxz/823woGZC0hLBSb2Ar/rOOeHiNbnPBum/Mw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "debug": "^4.3.1",
+        "js-sdsl": "^2.1.2"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true,
+      "peer": true
     },
     "nwsapi": {
       "version": "2.2.0",
@@ -10924,6 +14069,16 @@
         "word-wrap": "^1.2.3"
       }
     },
+    "os-locale": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "lcid": "^1.0.0"
+      }
+    },
     "p-limit": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -10998,6 +14153,23 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "path-to-regexp": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
     },
     "path-type": {
       "version": "4.0.0",
@@ -11123,6 +14295,13 @@
         }
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "peer": true
+    },
     "prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -11139,6 +14318,17 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -11151,17 +14341,62 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "dependencies": {
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
     "react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
+    },
+    "reinterval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+      "integrity": "sha1-M2Hs+jymwYKDOA3Qu5VG85D17Oc=",
+      "dev": true,
+      "peer": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -11215,6 +14450,13 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
+    "rfdc": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
+      "dev": true,
+      "peer": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -11260,6 +14502,13 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+      "dev": true,
+      "peer": true
+    },
     "shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -11292,6 +14541,31 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
     },
+    "sinon": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-11.1.2.tgz",
+      "integrity": "sha512-59237HChms4kg7/sXhiRcUzdSkKuydDeTiamT/jesUVHshBgL8XAmhgFo0GfK6RruMDM/iRSij1EybmMog9cJw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.8.3",
+        "@sinonjs/fake-timers": "^7.1.2",
+        "@sinonjs/samsam": "^6.0.2",
+        "diff": "^5.0.0",
+        "nise": "^5.1.0",
+        "supports-color": "^7.2.0"
+      },
+      "dependencies": {
+        "@sinonjs/fake-timers": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+          "integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
+          "dev": true,
+          "requires": {
+            "@sinonjs/commons": "^1.7.0"
+          }
+        }
+      }
+    },
     "sisteransi": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -11320,6 +14594,37 @@
         "source-map": "^0.6.0"
       }
     },
+    "split2": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+      "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "readable-stream": "^3.0.0"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
+    "splitargs": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
+      "integrity": "sha1-/p965lc3GzOxDLgNoUPPgknPazs=",
+      "dev": true,
+      "peer": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -11341,6 +14646,23 @@
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
           "dev": true
         }
+      }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true,
+      "peer": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "string-length": {
@@ -11442,6 +14764,21 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "tar": {
+      "version": "6.1.11",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.1.11.tgz",
+      "integrity": "sha512-an/KZQzQUkZCkuoAA64hM92X0Urb6VpRhAFllDzz44U2mcD5scmT3zBc4VgVpkugF580+DQn8eAFSyoQt0tznA==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^3.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      }
+    },
     "terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -11516,6 +14853,13 @@
         "punycode": "^2.1.1"
       }
     },
+    "traverse": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
+      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
+      "dev": true,
+      "peer": true
+    },
     "tsconfig-paths": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.12.0.tgz",
@@ -11588,6 +14932,13 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true,
+      "peer": true
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -11622,6 +14973,56 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
+    "unzipper": {
+      "version": "0.8.14",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
+      "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "big-integer": "^1.6.17",
+        "binary": "~0.3.0",
+        "bluebird": "~3.4.1",
+        "buffer-indexof-polyfill": "~1.0.0",
+        "duplexer2": "~0.1.4",
+        "fstream": "~1.0.10",
+        "listenercount": "~1.0.1",
+        "readable-stream": "~2.1.5",
+        "setimmediate": "~1.0.4"
+      },
+      "dependencies": {
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+          "dev": true,
+          "peer": true
+        },
+        "readable-stream": {
+          "version": "2.1.5",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
+          "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "buffer-shims": "^1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~0.10.x",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -11630,6 +15031,20 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "url-join": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
+      "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g=",
+      "dev": true,
+      "peer": true
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true,
+      "peer": true
     },
     "uuid": {
       "version": "8.3.2",
@@ -11742,6 +15157,13 @@
         "is-symbol": "^1.0.3"
       }
     },
+    "window-size": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
+      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+      "dev": true,
+      "peer": true
+    },
     "word-wrap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
@@ -11795,6 +15217,13 @@
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
+      "peer": true
     },
     "y18n": {
       "version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.3.0",
       "license": "ISC",
       "dependencies": {
-        "@aws-sdk/client-dynamodb": "^3.51.0",
-        "@aws-sdk/lib-dynamodb": "^3.51.0"
+        "@aws-sdk/client-dynamodb": "^3.53.0",
+        "@aws-sdk/lib-dynamodb": "^3.53.0"
       },
       "devDependencies": {
-        "@types/jest": "^27.4.0",
+        "@types/jest": "^27.4.1",
         "aws-sdk-client-mock": "^0.6.0",
-        "eslint": "^8.7.0",
+        "eslint": "^8.10.0",
         "eslint-config-airbnb-base": "15.0.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.25.4",
@@ -136,6 +136,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.52.0.tgz",
       "integrity": "sha512-Z+4uVtgwbKSChruh6R/WIrGb5uvvXi/d6EQ7zC6hyghtn9EGQc+WJ3BVB4bIUshwMunlgjA3nDiPb5V3t5zv8Q==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
@@ -166,49 +168,636 @@
       }
     },
     "node_modules/@aws-sdk/client-dynamodb": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.52.0.tgz",
-      "integrity": "sha512-SzKpt59qp+oh41yiIe3g3CmYc2xryvDekZUoKk4LlKPp4o8nH8+2WkgvRAnvTcASW48qrxYCvviCDvkpYnjeWA==",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.53.0.tgz",
+      "integrity": "sha512-U4SW2uQnVDEm6TtdHHcY6e5zo7puwjtcOWS+lDyPb/uQTlYk0DoBEuBuGA9d7DCLdSb6/dR5QKJJnr9nDCFcaw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.52.0",
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/credential-provider-node": "3.52.0",
-        "@aws-sdk/fetch-http-handler": "3.52.0",
-        "@aws-sdk/hash-node": "3.52.0",
-        "@aws-sdk/invalid-dependency": "3.52.0",
-        "@aws-sdk/middleware-content-length": "3.52.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.52.0",
-        "@aws-sdk/middleware-host-header": "3.52.0",
-        "@aws-sdk/middleware-logger": "3.52.0",
-        "@aws-sdk/middleware-retry": "3.52.0",
-        "@aws-sdk/middleware-serde": "3.52.0",
-        "@aws-sdk/middleware-signing": "3.52.0",
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/middleware-user-agent": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/node-http-handler": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/smithy-client": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
+        "@aws-sdk/client-sts": "3.53.0",
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/credential-provider-node": "3.53.0",
+        "@aws-sdk/fetch-http-handler": "3.53.0",
+        "@aws-sdk/hash-node": "3.53.0",
+        "@aws-sdk/invalid-dependency": "3.53.0",
+        "@aws-sdk/middleware-content-length": "3.53.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.53.0",
+        "@aws-sdk/middleware-host-header": "3.53.0",
+        "@aws-sdk/middleware-logger": "3.53.0",
+        "@aws-sdk/middleware-retry": "3.53.0",
+        "@aws-sdk/middleware-serde": "3.53.0",
+        "@aws-sdk/middleware-signing": "3.53.0",
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/middleware-user-agent": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/node-http-handler": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/smithy-client": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
         "@aws-sdk/util-base64-browser": "3.52.0",
         "@aws-sdk/util-base64-node": "3.52.0",
         "@aws-sdk/util-body-length-browser": "3.52.0",
         "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.52.0",
-        "@aws-sdk/util-defaults-mode-node": "3.52.0",
-        "@aws-sdk/util-user-agent-browser": "3.52.0",
-        "@aws-sdk/util-user-agent-node": "3.52.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+        "@aws-sdk/util-defaults-mode-node": "3.53.0",
+        "@aws-sdk/util-user-agent-browser": "3.53.0",
+        "@aws-sdk/util-user-agent-node": "3.53.0",
         "@aws-sdk/util-utf8-browser": "3.52.0",
         "@aws-sdk/util-utf8-node": "3.52.0",
-        "@aws-sdk/util-waiter": "3.52.0",
+        "@aws-sdk/util-waiter": "3.53.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/abort-controller": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.53.0.tgz",
+      "integrity": "sha512-Xe7IX2mpf/qOjh1LrPnJ1UtiDw3cBlmy8n+Q2xSP5vaS/9IH0OMdQUveC9MV9HSgzICX+xzbPyUuSKc+4tufBQ==",
+      "dependencies": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sso": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.53.0.tgz",
+      "integrity": "sha512-X32YHHc5MO7xO4W3Ly8DeryieeEiDOsnl6ypBkfML7loO3M0ckvvL+HnNUR1J+HYyseEV7V93BsF/A1z5HmINQ==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/fetch-http-handler": "3.53.0",
+        "@aws-sdk/hash-node": "3.53.0",
+        "@aws-sdk/invalid-dependency": "3.53.0",
+        "@aws-sdk/middleware-content-length": "3.53.0",
+        "@aws-sdk/middleware-host-header": "3.53.0",
+        "@aws-sdk/middleware-logger": "3.53.0",
+        "@aws-sdk/middleware-retry": "3.53.0",
+        "@aws-sdk/middleware-serde": "3.53.0",
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/middleware-user-agent": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/node-http-handler": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/smithy-client": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
+        "@aws-sdk/util-base64-browser": "3.52.0",
+        "@aws-sdk/util-base64-node": "3.52.0",
+        "@aws-sdk/util-body-length-browser": "3.52.0",
+        "@aws-sdk/util-body-length-node": "3.52.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+        "@aws-sdk/util-defaults-mode-node": "3.53.0",
+        "@aws-sdk/util-user-agent-browser": "3.53.0",
+        "@aws-sdk/util-user-agent-node": "3.53.0",
+        "@aws-sdk/util-utf8-browser": "3.52.0",
+        "@aws-sdk/util-utf8-node": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/client-sts": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.53.0.tgz",
+      "integrity": "sha512-MNG+Pmw/zZQ0kboZtsc8UEGM9pn8abjStDN0Yk67fwFAZMqz8sUHDtFXpa3gSXMrFqBwT+jMFXmIxqiq7XuAeA==",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/credential-provider-node": "3.53.0",
+        "@aws-sdk/fetch-http-handler": "3.53.0",
+        "@aws-sdk/hash-node": "3.53.0",
+        "@aws-sdk/invalid-dependency": "3.53.0",
+        "@aws-sdk/middleware-content-length": "3.53.0",
+        "@aws-sdk/middleware-host-header": "3.53.0",
+        "@aws-sdk/middleware-logger": "3.53.0",
+        "@aws-sdk/middleware-retry": "3.53.0",
+        "@aws-sdk/middleware-sdk-sts": "3.53.0",
+        "@aws-sdk/middleware-serde": "3.53.0",
+        "@aws-sdk/middleware-signing": "3.53.0",
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/middleware-user-agent": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/node-http-handler": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/smithy-client": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
+        "@aws-sdk/util-base64-browser": "3.52.0",
+        "@aws-sdk/util-base64-node": "3.52.0",
+        "@aws-sdk/util-body-length-browser": "3.52.0",
+        "@aws-sdk/util-body-length-node": "3.52.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+        "@aws-sdk/util-defaults-mode-node": "3.53.0",
+        "@aws-sdk/util-user-agent-browser": "3.53.0",
+        "@aws-sdk/util-user-agent-node": "3.53.0",
+        "@aws-sdk/util-utf8-browser": "3.52.0",
+        "@aws-sdk/util-utf8-node": "3.52.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.53.0.tgz",
+      "integrity": "sha512-wAqP/xNx49H1dutHWHjhKduaKtAcDg2KoH25W6peW2qXZ6OfpVcxRIBbJE4Z0yGOmFFaxw0OeH3h2ptP7tdhGQ==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-config-provider": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.53.0.tgz",
+      "integrity": "sha512-ocqZ4w7y7eay2M+uUBAD6NkhikUPoajEFX1/7iMvEFMmS5MyzjuolHPNK7Hh8lFmPyoflxaMXJVKO8C1MguA/A==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.53.0.tgz",
+      "integrity": "sha512-aKc8POSqCi58566KhF1p8Sxt7LHehMnshyfQzNAOB7xshSxuWg41rxafnQU4Soq9Tz7q5bwkauR2CEUihv/TRg==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.53.0.tgz",
+      "integrity": "sha512-g+UoJ1ikDrfpI1wHAhlrcBtX4OHxoLV6vakirpG27hhFwuMih565Q/Sjn3o5hLT8PBlWxwT2YeRuxCjtaL3cDA==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.53.0",
+        "@aws-sdk/credential-provider-imds": "3.53.0",
+        "@aws-sdk/credential-provider-sso": "3.53.0",
+        "@aws-sdk/credential-provider-web-identity": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/shared-ini-file-loader": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-credentials": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.53.0.tgz",
+      "integrity": "sha512-sy0NeuJHOBhe7XwxCX2y+YZAB4CqcHveyXJfT6mv7eY6bYQskkMTCPp2D586hSH3c6cfIsmvLSxNhNJApj1Atw==",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.53.0",
+        "@aws-sdk/credential-provider-imds": "3.53.0",
+        "@aws-sdk/credential-provider-ini": "3.53.0",
+        "@aws-sdk/credential-provider-process": "3.53.0",
+        "@aws-sdk/credential-provider-sso": "3.53.0",
+        "@aws-sdk/credential-provider-web-identity": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/shared-ini-file-loader": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-credentials": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.53.0.tgz",
+      "integrity": "sha512-nazHndueCa4y5jUM58OHSysb52E953r3VhmpCs0qIv1ZH5Ijs3kT/usbUq7Yms7pcpaUmpu00VZTc6IfOOC0GA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/shared-ini-file-loader": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-credentials": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.53.0.tgz",
+      "integrity": "sha512-EongClNxdVw+O4y+S0mZFjNeLHv1ssdAnBM/9L1PfR6sH06eikVmU6isEN2quwoKBy9HRVPaIVF075Q8QIpipg==",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/shared-ini-file-loader": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-credentials": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.53.0.tgz",
+      "integrity": "sha512-YbysBkX3mbomHJZULxk/3jyQ7NWn6rZ68IDY28bmp8cNWajWeGzDxKmR4Y+c8gNiN2ziWjUZWfHcnZC056/79Q==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.53.0.tgz",
+      "integrity": "sha512-0CcEYarIAVAoGzu1ClO2xDq30Jii6AevDFJYR7M9yojqAMvwjP31DY4/qfPc2nCpSAd9dASR6vcx6r/RoIynVg==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/querystring-builder": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-base64-browser": "3.52.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/hash-node": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.53.0.tgz",
+      "integrity": "sha512-0xK5PSUUVOPttvCLWrrUTmrKe7Fz6njPdBYvB3ESk1whXL+TY3syJj4em63Sq6yFyeuXdqyTzqfcs9fU2puWkA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-buffer-from": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.53.0.tgz",
+      "integrity": "sha512-qp2qRFa1a/AjZRCe6MZCpbaXo5t4enGAtch/83fuH4rRkzVOctYox1gyTGTliHk28rjMREtSgZDQZojp5/5M5w==",
+      "dependencies": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.53.0.tgz",
+      "integrity": "sha512-CXANhpL2MAE2tPKmu0cOf4Fd99useIj5kgX6UA+HWg/ZbJ4qBg6Q4W/nYVt+OuukeqwEEbpt3wv0lKQ8k/vINQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.53.0.tgz",
+      "integrity": "sha512-w5qMAUgy52fvJGqzqruNJhv4BtkanE4I368zWiysmwXXL5xmpKs8TpkGqcSQw4g2wKS8MR2Yxh21LukHlsgAJw==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.53.0.tgz",
+      "integrity": "sha512-jMME8OOyPHliHhVD3FaBQ+4X+FDCQovw6CYGqPdqP0JUuhR8E1LWKHV1+xRpkpOICKwBnIXrgD8/0NQo/+Z84A==",
+      "dependencies": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.53.0.tgz",
+      "integrity": "sha512-TKEdTLP//SjasunU3/yX7avXMxhIEDoSOaiwj77zEpPGF2NWcR99UFfqNLeJsRPCyzYScYo1JSuxIwgXHNIhyQ==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/service-error-classification": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.53.0.tgz",
+      "integrity": "sha512-b9AUXYqA5jaUTpWu7wPZz43RQnmy1WGPFVHd8CvcUzFdMzwJlQeH4wq+sEdZ1KtIsz6n6TmY7vobzrScgq3ftg==",
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/signature-v4": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.53.0.tgz",
+      "integrity": "sha512-jPoou51ULWN2PpvWkDF3wLKnTezyM33NBdF89mvfnI4++Za0/NpuL12636YqWLXt2CK87u8cA2Q+7Opob7KocA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.53.0.tgz",
+      "integrity": "sha512-r3g2ytin1YbhXCDedMfR7ZSlt1B39GWA0+J04ZZzUdevtnS2VnkFNhsanO5os/WOpVUV7iqk/ncJgSpn9LI2DA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/signature-v4": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.53.0.tgz",
+      "integrity": "sha512-YanQOVUXGjm63GCZVRYPlPMl6niaWtVjE2C0+0lpCrJQYaUIrvKh27Ff40JLi3U0F89hmsYOO7yPQOPTbc9NBg==",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.53.0.tgz",
+      "integrity": "sha512-ClKxpFXoHLhdnDxyDRRVNaFYQnfylps7rk1wfbRLWb+FWQwKWBvLq5c5ZPvznBU8BvftDSkFtrY+7OLMlj6qxA==",
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.53.0.tgz",
+      "integrity": "sha512-l00gDzU7n2WSIBHZPVW8/t6L0UD6qwtre5kuGKiv8ZkZKynPg9VV39IB/JZ7swp2uydbXuqxgDxFvqImvY3IyA==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/shared-ini-file-loader": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.53.0.tgz",
+      "integrity": "sha512-YqovPyn75gNzDSvPWQUTAEbwhr8PBdp1MQz65bB8p+qOlzQi1jGCyj1uHqG7qwVIlis9+bAfqpAqNDuYpdGsNg==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/querystring-builder": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/property-provider": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.53.0.tgz",
+      "integrity": "sha512-qrVFYcOV/Da7/ozW2bDLDz0JQP0NLIn6/eNUwT2fqKVw9MWcrLf6xtyAJhCwckdUVOWS2HoBSyvEopa4mdh9Sw==",
+      "dependencies": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
+      "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.53.0.tgz",
+      "integrity": "sha512-oliOrup52985pSKOjHbbm7t3bGL0HTPs9UODhBuDpHE7l0pdWE1hv9YiU3FF5NUIF25VwbL83GYmL9R52GxZhA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-uri-escape": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.53.0.tgz",
+      "integrity": "sha512-wEkS40w/wW4eBSnf7xt+m8InZFVzjLAzRYK1yPab2qfOIShpWgxg1ndqEP0eu14MvwdEfMPW9xU6J2AiWoxWng==",
+      "dependencies": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.53.0.tgz",
+      "integrity": "sha512-l5g8QncKk0ZmzQL7mWyQ6n5xWkd1XQJuoOfLZPBas9SJAyz7wanV5P3CG9PX6s1GVHWLC+2MafpIQ6+aH1x5cQ==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.53.0.tgz",
+      "integrity": "sha512-CUvCIrwiiWpJd/ldSA04RERXPsdvkuKW3+gBDIUREq4uc7co7Cml1/wbIJ0UOHAmJpDw82NDYqAUthYB1kbHrQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-hex-encoding": "3.52.0",
+        "@aws-sdk/util-uri-escape": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/smithy-client": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.53.0.tgz",
+      "integrity": "sha512-/mZn1/1/BXFgV5PwbGfXczbSyZFrhUEhWQzPG7x1NXLQh3kcSoHGDSONqFhqTeHWkfEXp1Tn0zUe7R4vAseFmQ==",
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/types": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+      "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg==",
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/url-parser": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.53.0.tgz",
+      "integrity": "sha512-lB0U5TkBDSdJK8h3noDkSG/P1cGnpSxOxBroMgPHA8Lrf5lmFRMvDXLXMhRDnTiqtsd/DpHDPyat91pfwLVEwA==",
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-credentials": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.53.0.tgz",
+      "integrity": "sha512-XP/3mYOmSn5KpWv+PnBTP2UExXb+hx1ugbH4Gkveshdq9KBlVnpV5eVgIwSAnKBsplScfsNMJ5EOtHjz5Cvu5A==",
+      "dependencies": {
+        "@aws-sdk/shared-ini-file-loader": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.53.0.tgz",
+      "integrity": "sha512-ubOcZT3rkVXSTwCHeIJevgBVV5GHnejz3hd+dFY9OcuK53oMZnFPS8SfJLgGG6PHfg30P8EurKv1VhWrbuuJDw==",
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.53.0.tgz",
+      "integrity": "sha512-84nczaF0eZMRkZ7chJh7OZd4ekV31eWmw8LOTJ4RQeeRy+0eY8th23yKyt5TU+YgmMLrY0BVK7103BQAI/6ccQ==",
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/credential-provider-imds": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/property-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.53.0.tgz",
+      "integrity": "sha512-fJsxzjo4UMv2o6KYSvw8cwfDhAQiao3X+iY1lGNVKrcY2bnI4zW5pWYge94oIJXMyFjjg6k6Ek+JIvGLMFY0XA==",
+      "dependencies": {
+        "@aws-sdk/types": "3.53.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.53.0.tgz",
+      "integrity": "sha512-YbrqMpTi+ArL9qG+NIXPInmnjGwYu0lohiH5uyEMHAHolqg4vqdKBlXyZ7Pjls2Nka7px2UUfX/Ba2RIssBBMQ==",
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-dynamodb/node_modules/@aws-sdk/util-waiter": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.53.0.tgz",
+      "integrity": "sha512-WyiyHOzmiapbbwB8dtu7axRqu9u5+Mnp1/+k2Ia7cm0UMUTKLjdixPsaM89HNre3EMa8WHrDBnwyVmo/Khbq3w==",
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@aws-sdk/client-s3": {
@@ -276,6 +865,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.52.0.tgz",
       "integrity": "sha512-IvtZlZopWlWg6xnKSXAodWQaPcRySNBJLj68K6HJ8OVvBCgcXr53nNREArgPi0+KDzLsXqAZTRxvU5do/99PrA==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -316,6 +907,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.52.0.tgz",
       "integrity": "sha512-tPLHYY9RdWehBQlyrwOaw4B31PqW1HmNNKJ3+Hc6KnEaiOwMAwQd8L7BFbSVG8ajQBDAEBUTDAkSaZ8jTYdfQQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -361,6 +954,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.52.0.tgz",
       "integrity": "sha512-XKUCpPLMwdlqPtwutdMfAHWqGEPTDd14Dp01WyNhVtmTmsHkpFfLPpELLO1BczDS+jyoMUj+UDj9jHm4YLvXXg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/signature-v4": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -375,6 +970,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.52.0.tgz",
       "integrity": "sha512-9R8kTMQ3udNz7fyY/0rkU6Yhu0ALYQJZQ0lFCrxtNo2Nlo9taQtZgxhtRcv+EeqbTcJs91voNNz70HLbedtBUw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -388,6 +985,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.52.0.tgz",
       "integrity": "sha512-939kfHSkMLsOfQtO2nBqC/zAE1ecTOCAs72pKvVxrluGzDry4UtwlyQ4YGC04pYBRQeRIqvIOoVbADYJy4XjmQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/node-config-provider": "3.52.0",
         "@aws-sdk/property-provider": "3.52.0",
@@ -403,6 +1002,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.52.0.tgz",
       "integrity": "sha512-MCzWWPYoZjZ3C/X8UXXf9eRqgGJc3Y1QyFXIuQzNrVhffrFkYOkOUQsG4s5TuDr1MmGfxe83XtHQgATJ0fe3zw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.52.0",
         "@aws-sdk/credential-provider-imds": "3.52.0",
@@ -422,6 +1023,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.52.0.tgz",
       "integrity": "sha512-SUl+t2S7xKHxAkIfuyvucKQ/JemJ/bCsuCk2qtjTSiVjrLx65Rnfw14j+44JU8U5mP+xodpKNCpgIF5PHu1kKQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.52.0",
         "@aws-sdk/credential-provider-imds": "3.52.0",
@@ -443,6 +1046,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.52.0.tgz",
       "integrity": "sha512-DGaSprlcEGgFuCiXNH9moksa6/1vBmX/G/tt/ulpgFEJmKljoazIEgUse/6oPJT7t5jazydAqMRVp1HK3Jp/0A==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.52.0",
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
@@ -458,6 +1063,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.52.0.tgz",
       "integrity": "sha512-8Q0X4wro+sPMYkbZE/ZW+CBpjxGq/x/vv4yQh7zdHpNfANhqjTSR8tUCApemVcfPtwNhQNPpW8KrlWUIMguHdg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/client-sso": "3.52.0",
         "@aws-sdk/property-provider": "3.52.0",
@@ -474,6 +1081,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.52.0.tgz",
       "integrity": "sha512-+4qz0PZn9u6HRRNBO9YfIixdItukixPOtLP8tNlgriCh66BC6M1mAXXP/uq2x7kIaMRZtTo3Eey4T/tA0QMkOg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -573,6 +1182,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.52.0.tgz",
       "integrity": "sha512-pFXkCeEIcrgH8esRyUab1nnIo1cjUjrheqwb/MK3gJ363/kenT6IqYXOq0UO4mF7bn6IOz/yxODlhQIU6i1Vww==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.52.0",
         "@aws-sdk/querystring-builder": "3.52.0",
@@ -598,6 +1209,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.52.0.tgz",
       "integrity": "sha512-pN2dSSyyy0emFFtK6jgmzYXcJHITbfdPqR7UTQ1fj1wFvbURPN19C1f4uYbVDjuiUQX01hLclJDLnPy1BIzTGQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.52.0",
         "@aws-sdk/util-buffer-from": "3.52.0",
@@ -625,6 +1238,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.52.0.tgz",
       "integrity": "sha512-TjRzfFFiY4i/a9ry5llCQMiIwpyhIyriM2QuPgAdRaRPM076I01FohUzlAc7zgwwhCa5rpI4zRZ+auGPrU44Gw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
@@ -642,11 +1257,11 @@
       }
     },
     "node_modules/@aws-sdk/lib-dynamodb": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.52.0.tgz",
-      "integrity": "sha512-Ee+mRIgE+9BxAUlHiNaIP//iCbwGMWizmmnseFxXJW3tUZbdvNFGTH1fzp1UL0p+siqVotUTPSL6grWekWFiDg==",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.53.0.tgz",
+      "integrity": "sha512-WTc4TB+mheEcRg3iVmJEibpaACfG8Jye2HLAvt/HoObcdd3J34ag1stRV/CZpYb/2DO2nzL+vo1E7Kl8hwpKHg==",
       "dependencies": {
-        "@aws-sdk/util-dynamodb": "3.52.0",
+        "@aws-sdk/util-dynamodb": "3.53.0",
         "tslib": "^2.3.0"
       },
       "engines": {
@@ -708,6 +1323,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.52.0.tgz",
       "integrity": "sha512-U+aa8UswtEvEdt4vvX+C4b+vetSpG6PZVeGN/hZ2J0j3jQxODQtjKHU3VIO+Fvp8m9rSCtcfAPly5CcejHLeKw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -718,16 +1335,65 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.52.0.tgz",
-      "integrity": "sha512-qhDKtFEgEX8xpIKgM3h7qma3CORGrPXMB9s6zeRhYrJmH12uA9SjpSOSs5mZnvExbKuWxOK5ZULTIBprmV4WAg==",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.53.0.tgz",
+      "integrity": "sha512-VEa5I0zms9Q7nct0i51W+3Uu7M6koYda17fcMxISLqg7he7nZ3EiUFYh3bDDXoEvfI5Hw915DttTGQ6vkriaFg==",
       "dependencies": {
-        "@aws-sdk/config-resolver": "3.52.0",
+        "@aws-sdk/config-resolver": "3.53.0",
         "@aws-sdk/endpoint-cache": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
       },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/config-resolver": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.53.0.tgz",
+      "integrity": "sha512-wAqP/xNx49H1dutHWHjhKduaKtAcDg2KoH25W6peW2qXZ6OfpVcxRIBbJE4Z0yGOmFFaxw0OeH3h2ptP7tdhGQ==",
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-config-provider": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/protocol-http": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
+      "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+      "dependencies": {
+        "@aws-sdk/types": "3.53.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/signature-v4": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.53.0.tgz",
+      "integrity": "sha512-CUvCIrwiiWpJd/ldSA04RERXPsdvkuKW3+gBDIUREq4uc7co7Cml1/wbIJ0UOHAmJpDw82NDYqAUthYB1kbHrQ==",
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.52.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/util-hex-encoding": "3.52.0",
+        "@aws-sdk/util-uri-escape": "3.52.0",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint-discovery/node_modules/@aws-sdk/types": {
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+      "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg==",
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -767,6 +1433,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.52.0.tgz",
       "integrity": "sha512-t7y0gtJyFNrS6bwluR7N2LtppA7B0SDk+uNlvOJOYnJRms89fXltyMJWl8wrv8IHHvrhRLwNEP22vvOhn3hriA==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -794,6 +1462,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.52.0.tgz",
       "integrity": "sha512-YbFuJAsOPvbYe64gpqmS6XmEQXwyAGwH3Y4iOp3CnrGAz/zXbwWwzb653Uby+h4PVkTZ1+RviCO/A6si9bUkhw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
@@ -806,6 +1476,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.52.0.tgz",
       "integrity": "sha512-O+4mfn7OPv1POYagKwOgdlc16AQFWa4bY05g6Y94KZ2400ywNpK+Y2cwdskyNU3OTGOlluVGR21W5eO1b+XhNg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.52.0",
         "@aws-sdk/service-error-classification": "3.52.0",
@@ -841,6 +1513,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.52.0.tgz",
       "integrity": "sha512-NB1wHvOp+I6DXi5fPutyl9dAWvJYqzRqdi8lMeu02ub/d6nybrAjoB56za1LvGblcoEiYClf1A6dTKtmydgzFQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-signing": "3.52.0",
         "@aws-sdk/property-provider": "3.52.0",
@@ -857,6 +1531,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.52.0.tgz",
       "integrity": "sha512-4ZooINTdOI4+T6pEiu8xte5EEhOqbE/wqOwBzvOASk3JKElZ93u6xKP2u7UKVD6asBBYK2mDrYSy1PsU4fNl4A==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
@@ -869,6 +1545,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.52.0.tgz",
       "integrity": "sha512-7FUqmZQ5DzaDJYCJ3YmOHRFEyFeohtsDQ1akWD2qekcjp16ftBtk05Fi9am5/L7pO8svVzobji/wg00Tlq183A==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.52.0",
         "@aws-sdk/protocol-http": "3.52.0",
@@ -898,6 +1576,7 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.52.0.tgz",
       "integrity": "sha512-4OTbQ+tWc6Le7es3kSnXBzCyddcUw6Sk2GupR/1+PD9v4/qvtKXXK+uD4bMDDMfi6dTNV+2riOGBniOtBVsayw==",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -909,6 +1588,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.52.0.tgz",
       "integrity": "sha512-sfdJvAp/f4PHmQvSklFAuCpD7gqloG502gSmBAMrXKqYykvQ5SAGyr6sCZPWf8CZxKtn5n4ftg8CLKywwrKwmg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/protocol-http": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -922,6 +1603,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.52.0.tgz",
       "integrity": "sha512-vfeTzkfVtGaNQrnhCRMObqid0shxFtNFEnnU1Nnx7HsgBfag2/T6fnsDzdVGaliQ6nmfg+RMrhzw2VECyBTHQQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.52.0",
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
@@ -936,6 +1619,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.52.0.tgz",
       "integrity": "sha512-MjLkndwLuWye1kavyFnDw5BvK8Rg4YpMULTne++OL/uEsxWO786K+QQMyLWkirPe+ELMEYu/3eOrQTly2tqHsA==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/abort-controller": "3.52.0",
         "@aws-sdk/protocol-http": "3.52.0",
@@ -951,6 +1636,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.52.0.tgz",
       "integrity": "sha512-Ooam7CvGefHKhMwQ413MiEtDTFw70xbCduJCF7Bg1F0WKrf700M/Yte+q3E0ljlXWJ28rwJNgwW3ptZaSXMGPg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
@@ -963,6 +1650,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.52.0.tgz",
       "integrity": "sha512-L6ITU9NG0L6nyYfzhSLa0EsgDlyL1vHNz+Om9o7TayUUF7O0f3UiZToWf2hdETQ04Os8625aZt0VH92ZnYyeEw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
@@ -975,6 +1664,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.52.0.tgz",
       "integrity": "sha512-RfNXqKeR6mdg2n2LO5Vs2Bz+f47/KN5k36HWk04bSwIbhnBtslXBp0F1KgSPkeP56KEgmmUWldRD7g8BvDkgAw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.52.0",
         "@aws-sdk/util-uri-escape": "3.52.0",
@@ -988,6 +1679,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.52.0.tgz",
       "integrity": "sha512-/A6PauieStZajbkxX3sZSBBDacGDc3I/Sk7rjJulmg1GnizeVcUgx1OUdDh1JasdqA1h9E3ks/Y2Lu3xUMctLw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
@@ -1000,6 +1693,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.52.0.tgz",
       "integrity": "sha512-2bpSIZCx5VGp2CBTeXK6PxlBYWrn2wiqxBVYstDRExZ8P7edcwPRgWi8qaKgPM2wvstZwJieF774niiuLddIpg==",
+      "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       }
@@ -1019,6 +1714,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.52.0.tgz",
       "integrity": "sha512-lSlDASXGLup5v12kclzT2ZLoUnnVLknSRcMXrTVjnX7spmHMbs6s7LOcN0RXZzFIACs7vW+930KUzhBxt8UiFQ==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/is-array-buffer": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -1053,6 +1750,7 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.52.0.tgz",
       "integrity": "sha512-GuOJuoA1kky/v2p7byOZGq7YOiu2Ov8DA3d58gM6L/q7XavBjnzwNB/BYU7SPU3Ly6S7qGxBJFeadufic4bCYg==",
+      "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-stack": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -1074,6 +1772,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.52.0.tgz",
       "integrity": "sha512-/9OJwol/384jsISiAs5JX7fkgd9mv7hJsHFCVXnByim5qTZu1V9fMcJYJ1L3iRmfCRy0w75UDJljIx2RZnwAYw==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/querystring-parser": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -1159,6 +1859,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.52.0.tgz",
       "integrity": "sha512-fNcm2cNzDHWt5Pr6xD2FXA40jkcgClsbumuI0VBhLEyNLfoetwPImKTpqbxo1XfWVxhqIbT/ELnrbS2OYBRIXg==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
         "tslib": "^2.3.0"
@@ -1171,6 +1873,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.52.0.tgz",
       "integrity": "sha512-N2/DHJ/OfiQ5zP97k9cJ8jSGiWDjtR7oFqXR+wbKZzKOww6vencMPYlndU6v1uZOKEjoj+NBr5N0jPEjCz+6+g==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/property-provider": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -1185,6 +1889,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.52.0.tgz",
       "integrity": "sha512-vmbvirg5edfNKBin8Mup2noxgqIYzYPnvk+BgIx3jFPvwT57WGRs/ahOMNqHgv/6xAdVaUjz8g7gw9Yy3mwP3A==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/config-resolver": "3.52.0",
         "@aws-sdk/credential-provider-imds": "3.52.0",
@@ -1198,9 +1904,9 @@
       }
     },
     "node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.52.0.tgz",
-      "integrity": "sha512-Y7ehxs4+D4d8+zWqVrZ9BfDsdGSzpzywQjUnP6Zqm+yzzcgttjjEE3NgQQjWtoYqrjfZcZkCo3mb5x6PjYMcLg==",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.53.0.tgz",
+      "integrity": "sha512-YY9dSk/VcuJAZRG1xE8DN1D3dhqEHmefw3cNt+Aecqu+bp7Zx5/sd1FbdyDg3+QKme6hPkuZHtleiohhC8TvEQ==",
       "dependencies": {
         "tslib": "^2.3.0"
       },
@@ -1245,6 +1951,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.52.0.tgz",
       "integrity": "sha512-zmw9pJ91QAr1oF3uqLKuo/3++NrSEagLwz3xnuID5wN8WLAgbC6MkvM7FG+r11CHSoUX3IeB6YDqoBMQW8en8w==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/types": "3.52.0",
         "bowser": "^2.11.0",
@@ -1255,6 +1963,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.52.0.tgz",
       "integrity": "sha512-jqbyb6R4goWOTIESizmNPy1i3Xa25Q3QG0xt6Pct0DwLQUSVpnPHw07NmfRhql+eYBoD4uxpXDX9lWsuLUBi0w==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/node-config-provider": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -1288,6 +1998,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.52.0.tgz",
       "integrity": "sha512-8Gx0NunIg1RFpnKSA3nwzDl5j8mJ42kWjy5sHgd4wfUyiXRSvTl69sV6O8qhleI9OMDV0iS4xHZBCLK11HdIoA==",
+      "dev": true,
+      "peer": true,
       "dependencies": {
         "@aws-sdk/abort-controller": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -1871,9 +2583,9 @@
       "dev": true
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
-      "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
+      "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -2481,12 +3193,12 @@
       }
     },
     "node_modules/@types/jest": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.0.tgz",
-      "integrity": "sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==",
+      "version": "27.4.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
+      "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
       "dev": true,
       "dependencies": {
-        "jest-diff": "^27.0.0",
+        "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
       }
     },
@@ -4228,12 +4940,12 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
-      "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
+      "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
       "dev": true,
       "dependencies": {
-        "@eslint/eslintrc": "^1.1.0",
+        "@eslint/eslintrc": "^1.2.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",
@@ -8667,6 +9379,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.52.0.tgz",
       "integrity": "sha512-Z+4uVtgwbKSChruh6R/WIrGb5uvvXi/d6EQ7zC6hyghtn9EGQc+WJ3BVB4bIUshwMunlgjA3nDiPb5V3t5zv8Q==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
@@ -8694,46 +9408,527 @@
       }
     },
     "@aws-sdk/client-dynamodb": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.52.0.tgz",
-      "integrity": "sha512-SzKpt59qp+oh41yiIe3g3CmYc2xryvDekZUoKk4LlKPp4o8nH8+2WkgvRAnvTcASW48qrxYCvviCDvkpYnjeWA==",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.53.0.tgz",
+      "integrity": "sha512-U4SW2uQnVDEm6TtdHHcY6e5zo7puwjtcOWS+lDyPb/uQTlYk0DoBEuBuGA9d7DCLdSb6/dR5QKJJnr9nDCFcaw==",
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.52.0",
-        "@aws-sdk/config-resolver": "3.52.0",
-        "@aws-sdk/credential-provider-node": "3.52.0",
-        "@aws-sdk/fetch-http-handler": "3.52.0",
-        "@aws-sdk/hash-node": "3.52.0",
-        "@aws-sdk/invalid-dependency": "3.52.0",
-        "@aws-sdk/middleware-content-length": "3.52.0",
-        "@aws-sdk/middleware-endpoint-discovery": "3.52.0",
-        "@aws-sdk/middleware-host-header": "3.52.0",
-        "@aws-sdk/middleware-logger": "3.52.0",
-        "@aws-sdk/middleware-retry": "3.52.0",
-        "@aws-sdk/middleware-serde": "3.52.0",
-        "@aws-sdk/middleware-signing": "3.52.0",
-        "@aws-sdk/middleware-stack": "3.52.0",
-        "@aws-sdk/middleware-user-agent": "3.52.0",
-        "@aws-sdk/node-config-provider": "3.52.0",
-        "@aws-sdk/node-http-handler": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/smithy-client": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
-        "@aws-sdk/url-parser": "3.52.0",
+        "@aws-sdk/client-sts": "3.53.0",
+        "@aws-sdk/config-resolver": "3.53.0",
+        "@aws-sdk/credential-provider-node": "3.53.0",
+        "@aws-sdk/fetch-http-handler": "3.53.0",
+        "@aws-sdk/hash-node": "3.53.0",
+        "@aws-sdk/invalid-dependency": "3.53.0",
+        "@aws-sdk/middleware-content-length": "3.53.0",
+        "@aws-sdk/middleware-endpoint-discovery": "3.53.0",
+        "@aws-sdk/middleware-host-header": "3.53.0",
+        "@aws-sdk/middleware-logger": "3.53.0",
+        "@aws-sdk/middleware-retry": "3.53.0",
+        "@aws-sdk/middleware-serde": "3.53.0",
+        "@aws-sdk/middleware-signing": "3.53.0",
+        "@aws-sdk/middleware-stack": "3.53.0",
+        "@aws-sdk/middleware-user-agent": "3.53.0",
+        "@aws-sdk/node-config-provider": "3.53.0",
+        "@aws-sdk/node-http-handler": "3.53.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/smithy-client": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
+        "@aws-sdk/url-parser": "3.53.0",
         "@aws-sdk/util-base64-browser": "3.52.0",
         "@aws-sdk/util-base64-node": "3.52.0",
         "@aws-sdk/util-body-length-browser": "3.52.0",
         "@aws-sdk/util-body-length-node": "3.52.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.52.0",
-        "@aws-sdk/util-defaults-mode-node": "3.52.0",
-        "@aws-sdk/util-user-agent-browser": "3.52.0",
-        "@aws-sdk/util-user-agent-node": "3.52.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+        "@aws-sdk/util-defaults-mode-node": "3.53.0",
+        "@aws-sdk/util-user-agent-browser": "3.53.0",
+        "@aws-sdk/util-user-agent-node": "3.53.0",
         "@aws-sdk/util-utf8-browser": "3.52.0",
         "@aws-sdk/util-utf8-node": "3.52.0",
-        "@aws-sdk/util-waiter": "3.52.0",
+        "@aws-sdk/util-waiter": "3.53.0",
         "tslib": "^2.3.0",
         "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.53.0.tgz",
+          "integrity": "sha512-Xe7IX2mpf/qOjh1LrPnJ1UtiDw3cBlmy8n+Q2xSP5vaS/9IH0OMdQUveC9MV9HSgzICX+xzbPyUuSKc+4tufBQ==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.53.0.tgz",
+          "integrity": "sha512-X32YHHc5MO7xO4W3Ly8DeryieeEiDOsnl6ypBkfML7loO3M0ckvvL+HnNUR1J+HYyseEV7V93BsF/A1z5HmINQ==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.53.0",
+            "@aws-sdk/fetch-http-handler": "3.53.0",
+            "@aws-sdk/hash-node": "3.53.0",
+            "@aws-sdk/invalid-dependency": "3.53.0",
+            "@aws-sdk/middleware-content-length": "3.53.0",
+            "@aws-sdk/middleware-host-header": "3.53.0",
+            "@aws-sdk/middleware-logger": "3.53.0",
+            "@aws-sdk/middleware-retry": "3.53.0",
+            "@aws-sdk/middleware-serde": "3.53.0",
+            "@aws-sdk/middleware-stack": "3.53.0",
+            "@aws-sdk/middleware-user-agent": "3.53.0",
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/node-http-handler": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/smithy-client": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/url-parser": "3.53.0",
+            "@aws-sdk/util-base64-browser": "3.52.0",
+            "@aws-sdk/util-base64-node": "3.52.0",
+            "@aws-sdk/util-body-length-browser": "3.52.0",
+            "@aws-sdk/util-body-length-node": "3.52.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+            "@aws-sdk/util-defaults-mode-node": "3.53.0",
+            "@aws-sdk/util-user-agent-browser": "3.53.0",
+            "@aws-sdk/util-user-agent-node": "3.53.0",
+            "@aws-sdk/util-utf8-browser": "3.52.0",
+            "@aws-sdk/util-utf8-node": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.53.0.tgz",
+          "integrity": "sha512-MNG+Pmw/zZQ0kboZtsc8UEGM9pn8abjStDN0Yk67fwFAZMqz8sUHDtFXpa3gSXMrFqBwT+jMFXmIxqiq7XuAeA==",
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.53.0",
+            "@aws-sdk/credential-provider-node": "3.53.0",
+            "@aws-sdk/fetch-http-handler": "3.53.0",
+            "@aws-sdk/hash-node": "3.53.0",
+            "@aws-sdk/invalid-dependency": "3.53.0",
+            "@aws-sdk/middleware-content-length": "3.53.0",
+            "@aws-sdk/middleware-host-header": "3.53.0",
+            "@aws-sdk/middleware-logger": "3.53.0",
+            "@aws-sdk/middleware-retry": "3.53.0",
+            "@aws-sdk/middleware-sdk-sts": "3.53.0",
+            "@aws-sdk/middleware-serde": "3.53.0",
+            "@aws-sdk/middleware-signing": "3.53.0",
+            "@aws-sdk/middleware-stack": "3.53.0",
+            "@aws-sdk/middleware-user-agent": "3.53.0",
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/node-http-handler": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/smithy-client": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/url-parser": "3.53.0",
+            "@aws-sdk/util-base64-browser": "3.52.0",
+            "@aws-sdk/util-base64-node": "3.52.0",
+            "@aws-sdk/util-body-length-browser": "3.52.0",
+            "@aws-sdk/util-body-length-node": "3.52.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.53.0",
+            "@aws-sdk/util-defaults-mode-node": "3.53.0",
+            "@aws-sdk/util-user-agent-browser": "3.53.0",
+            "@aws-sdk/util-user-agent-node": "3.53.0",
+            "@aws-sdk/util-utf8-browser": "3.52.0",
+            "@aws-sdk/util-utf8-node": "3.52.0",
+            "entities": "2.2.0",
+            "fast-xml-parser": "3.19.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.53.0.tgz",
+          "integrity": "sha512-wAqP/xNx49H1dutHWHjhKduaKtAcDg2KoH25W6peW2qXZ6OfpVcxRIBbJE4Z0yGOmFFaxw0OeH3h2ptP7tdhGQ==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-config-provider": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.53.0.tgz",
+          "integrity": "sha512-ocqZ4w7y7eay2M+uUBAD6NkhikUPoajEFX1/7iMvEFMmS5MyzjuolHPNK7Hh8lFmPyoflxaMXJVKO8C1MguA/A==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.53.0.tgz",
+          "integrity": "sha512-aKc8POSqCi58566KhF1p8Sxt7LHehMnshyfQzNAOB7xshSxuWg41rxafnQU4Soq9Tz7q5bwkauR2CEUihv/TRg==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/url-parser": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.53.0.tgz",
+          "integrity": "sha512-g+UoJ1ikDrfpI1wHAhlrcBtX4OHxoLV6vakirpG27hhFwuMih565Q/Sjn3o5hLT8PBlWxwT2YeRuxCjtaL3cDA==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.53.0",
+            "@aws-sdk/credential-provider-imds": "3.53.0",
+            "@aws-sdk/credential-provider-sso": "3.53.0",
+            "@aws-sdk/credential-provider-web-identity": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-credentials": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.53.0.tgz",
+          "integrity": "sha512-sy0NeuJHOBhe7XwxCX2y+YZAB4CqcHveyXJfT6mv7eY6bYQskkMTCPp2D586hSH3c6cfIsmvLSxNhNJApj1Atw==",
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.53.0",
+            "@aws-sdk/credential-provider-imds": "3.53.0",
+            "@aws-sdk/credential-provider-ini": "3.53.0",
+            "@aws-sdk/credential-provider-process": "3.53.0",
+            "@aws-sdk/credential-provider-sso": "3.53.0",
+            "@aws-sdk/credential-provider-web-identity": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-credentials": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.53.0.tgz",
+          "integrity": "sha512-nazHndueCa4y5jUM58OHSysb52E953r3VhmpCs0qIv1ZH5Ijs3kT/usbUq7Yms7pcpaUmpu00VZTc6IfOOC0GA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-credentials": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.53.0.tgz",
+          "integrity": "sha512-EongClNxdVw+O4y+S0mZFjNeLHv1ssdAnBM/9L1PfR6sH06eikVmU6isEN2quwoKBy9HRVPaIVF075Q8QIpipg==",
+          "requires": {
+            "@aws-sdk/client-sso": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-credentials": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.53.0.tgz",
+          "integrity": "sha512-YbysBkX3mbomHJZULxk/3jyQ7NWn6rZ68IDY28bmp8cNWajWeGzDxKmR4Y+c8gNiN2ziWjUZWfHcnZC056/79Q==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.53.0.tgz",
+          "integrity": "sha512-0CcEYarIAVAoGzu1ClO2xDq30Jii6AevDFJYR7M9yojqAMvwjP31DY4/qfPc2nCpSAd9dASR6vcx6r/RoIynVg==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/querystring-builder": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-base64-browser": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.53.0.tgz",
+          "integrity": "sha512-0xK5PSUUVOPttvCLWrrUTmrKe7Fz6njPdBYvB3ESk1whXL+TY3syJj4em63Sq6yFyeuXdqyTzqfcs9fU2puWkA==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-buffer-from": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.53.0.tgz",
+          "integrity": "sha512-qp2qRFa1a/AjZRCe6MZCpbaXo5t4enGAtch/83fuH4rRkzVOctYox1gyTGTliHk28rjMREtSgZDQZojp5/5M5w==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.53.0.tgz",
+          "integrity": "sha512-CXANhpL2MAE2tPKmu0cOf4Fd99useIj5kgX6UA+HWg/ZbJ4qBg6Q4W/nYVt+OuukeqwEEbpt3wv0lKQ8k/vINQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.53.0.tgz",
+          "integrity": "sha512-w5qMAUgy52fvJGqzqruNJhv4BtkanE4I368zWiysmwXXL5xmpKs8TpkGqcSQw4g2wKS8MR2Yxh21LukHlsgAJw==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.53.0.tgz",
+          "integrity": "sha512-jMME8OOyPHliHhVD3FaBQ+4X+FDCQovw6CYGqPdqP0JUuhR8E1LWKHV1+xRpkpOICKwBnIXrgD8/0NQo/+Z84A==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.53.0.tgz",
+          "integrity": "sha512-TKEdTLP//SjasunU3/yX7avXMxhIEDoSOaiwj77zEpPGF2NWcR99UFfqNLeJsRPCyzYScYo1JSuxIwgXHNIhyQ==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/service-error-classification": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.53.0.tgz",
+          "integrity": "sha512-b9AUXYqA5jaUTpWu7wPZz43RQnmy1WGPFVHd8CvcUzFdMzwJlQeH4wq+sEdZ1KtIsz6n6TmY7vobzrScgq3ftg==",
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/signature-v4": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.53.0.tgz",
+          "integrity": "sha512-jPoou51ULWN2PpvWkDF3wLKnTezyM33NBdF89mvfnI4++Za0/NpuL12636YqWLXt2CK87u8cA2Q+7Opob7KocA==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.53.0.tgz",
+          "integrity": "sha512-r3g2ytin1YbhXCDedMfR7ZSlt1B39GWA0+J04ZZzUdevtnS2VnkFNhsanO5os/WOpVUV7iqk/ncJgSpn9LI2DA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/signature-v4": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.53.0.tgz",
+          "integrity": "sha512-YanQOVUXGjm63GCZVRYPlPMl6niaWtVjE2C0+0lpCrJQYaUIrvKh27Ff40JLi3U0F89hmsYOO7yPQOPTbc9NBg==",
+          "requires": {
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.53.0.tgz",
+          "integrity": "sha512-ClKxpFXoHLhdnDxyDRRVNaFYQnfylps7rk1wfbRLWb+FWQwKWBvLq5c5ZPvznBU8BvftDSkFtrY+7OLMlj6qxA==",
+          "requires": {
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.53.0.tgz",
+          "integrity": "sha512-l00gDzU7n2WSIBHZPVW8/t6L0UD6qwtre5kuGKiv8ZkZKynPg9VV39IB/JZ7swp2uydbXuqxgDxFvqImvY3IyA==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.53.0.tgz",
+          "integrity": "sha512-YqovPyn75gNzDSvPWQUTAEbwhr8PBdp1MQz65bB8p+qOlzQi1jGCyj1uHqG7qwVIlis9+bAfqpAqNDuYpdGsNg==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.53.0",
+            "@aws-sdk/protocol-http": "3.53.0",
+            "@aws-sdk/querystring-builder": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.53.0.tgz",
+          "integrity": "sha512-qrVFYcOV/Da7/ozW2bDLDz0JQP0NLIn6/eNUwT2fqKVw9MWcrLf6xtyAJhCwckdUVOWS2HoBSyvEopa4mdh9Sw==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
+          "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.53.0.tgz",
+          "integrity": "sha512-oliOrup52985pSKOjHbbm7t3bGL0HTPs9UODhBuDpHE7l0pdWE1hv9YiU3FF5NUIF25VwbL83GYmL9R52GxZhA==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-uri-escape": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.53.0.tgz",
+          "integrity": "sha512-wEkS40w/wW4eBSnf7xt+m8InZFVzjLAzRYK1yPab2qfOIShpWgxg1ndqEP0eu14MvwdEfMPW9xU6J2AiWoxWng==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.53.0.tgz",
+          "integrity": "sha512-l5g8QncKk0ZmzQL7mWyQ6n5xWkd1XQJuoOfLZPBas9SJAyz7wanV5P3CG9PX6s1GVHWLC+2MafpIQ6+aH1x5cQ=="
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.53.0.tgz",
+          "integrity": "sha512-CUvCIrwiiWpJd/ldSA04RERXPsdvkuKW3+gBDIUREq4uc7co7Cml1/wbIJ0UOHAmJpDw82NDYqAUthYB1kbHrQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-hex-encoding": "3.52.0",
+            "@aws-sdk/util-uri-escape": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.53.0.tgz",
+          "integrity": "sha512-/mZn1/1/BXFgV5PwbGfXczbSyZFrhUEhWQzPG7x1NXLQh3kcSoHGDSONqFhqTeHWkfEXp1Tn0zUe7R4vAseFmQ==",
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.53.0.tgz",
+          "integrity": "sha512-lB0U5TkBDSdJK8h3noDkSG/P1cGnpSxOxBroMgPHA8Lrf5lmFRMvDXLXMhRDnTiqtsd/DpHDPyat91pfwLVEwA==",
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-credentials": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.53.0.tgz",
+          "integrity": "sha512-XP/3mYOmSn5KpWv+PnBTP2UExXb+hx1ugbH4Gkveshdq9KBlVnpV5eVgIwSAnKBsplScfsNMJ5EOtHjz5Cvu5A==",
+          "requires": {
+            "@aws-sdk/shared-ini-file-loader": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.53.0.tgz",
+          "integrity": "sha512-ubOcZT3rkVXSTwCHeIJevgBVV5GHnejz3hd+dFY9OcuK53oMZnFPS8SfJLgGG6PHfg30P8EurKv1VhWrbuuJDw==",
+          "requires": {
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.53.0.tgz",
+          "integrity": "sha512-84nczaF0eZMRkZ7chJh7OZd4ekV31eWmw8LOTJ4RQeeRy+0eY8th23yKyt5TU+YgmMLrY0BVK7103BQAI/6ccQ==",
+          "requires": {
+            "@aws-sdk/config-resolver": "3.53.0",
+            "@aws-sdk/credential-provider-imds": "3.53.0",
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/property-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.53.0.tgz",
+          "integrity": "sha512-fJsxzjo4UMv2o6KYSvw8cwfDhAQiao3X+iY1lGNVKrcY2bnI4zW5pWYge94oIJXMyFjjg6k6Ek+JIvGLMFY0XA==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.53.0.tgz",
+          "integrity": "sha512-YbrqMpTi+ArL9qG+NIXPInmnjGwYu0lohiH5uyEMHAHolqg4vqdKBlXyZ7Pjls2Nka7px2UUfX/Ba2RIssBBMQ==",
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/util-waiter": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.53.0.tgz",
+          "integrity": "sha512-WyiyHOzmiapbbwB8dtu7axRqu9u5+Mnp1/+k2Ia7cm0UMUTKLjdixPsaM89HNre3EMa8WHrDBnwyVmo/Khbq3w==",
+          "requires": {
+            "@aws-sdk/abort-controller": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        }
       }
     },
     "@aws-sdk/client-s3": {
@@ -8798,6 +9993,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.52.0.tgz",
       "integrity": "sha512-IvtZlZopWlWg6xnKSXAodWQaPcRySNBJLj68K6HJ8OVvBCgcXr53nNREArgPi0+KDzLsXqAZTRxvU5do/99PrA==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -8835,6 +10032,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.52.0.tgz",
       "integrity": "sha512-tPLHYY9RdWehBQlyrwOaw4B31PqW1HmNNKJ3+Hc6KnEaiOwMAwQd8L7BFbSVG8ajQBDAEBUTDAkSaZ8jTYdfQQ==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-crypto/sha256-browser": "2.0.0",
         "@aws-crypto/sha256-js": "2.0.0",
@@ -8877,6 +10076,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.52.0.tgz",
       "integrity": "sha512-XKUCpPLMwdlqPtwutdMfAHWqGEPTDd14Dp01WyNhVtmTmsHkpFfLPpELLO1BczDS+jyoMUj+UDj9jHm4YLvXXg==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/signature-v4": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -8888,6 +10089,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.52.0.tgz",
       "integrity": "sha512-9R8kTMQ3udNz7fyY/0rkU6Yhu0ALYQJZQ0lFCrxtNo2Nlo9taQtZgxhtRcv+EeqbTcJs91voNNz70HLbedtBUw==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -8898,6 +10101,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.52.0.tgz",
       "integrity": "sha512-939kfHSkMLsOfQtO2nBqC/zAE1ecTOCAs72pKvVxrluGzDry4UtwlyQ4YGC04pYBRQeRIqvIOoVbADYJy4XjmQ==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/node-config-provider": "3.52.0",
         "@aws-sdk/property-provider": "3.52.0",
@@ -8910,6 +10115,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.52.0.tgz",
       "integrity": "sha512-MCzWWPYoZjZ3C/X8UXXf9eRqgGJc3Y1QyFXIuQzNrVhffrFkYOkOUQsG4s5TuDr1MmGfxe83XtHQgATJ0fe3zw==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.52.0",
         "@aws-sdk/credential-provider-imds": "3.52.0",
@@ -8926,6 +10133,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.52.0.tgz",
       "integrity": "sha512-SUl+t2S7xKHxAkIfuyvucKQ/JemJ/bCsuCk2qtjTSiVjrLx65Rnfw14j+44JU8U5mP+xodpKNCpgIF5PHu1kKQ==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/credential-provider-env": "3.52.0",
         "@aws-sdk/credential-provider-imds": "3.52.0",
@@ -8944,6 +10153,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.52.0.tgz",
       "integrity": "sha512-DGaSprlcEGgFuCiXNH9moksa6/1vBmX/G/tt/ulpgFEJmKljoazIEgUse/6oPJT7t5jazydAqMRVp1HK3Jp/0A==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.52.0",
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
@@ -8956,6 +10167,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.52.0.tgz",
       "integrity": "sha512-8Q0X4wro+sPMYkbZE/ZW+CBpjxGq/x/vv4yQh7zdHpNfANhqjTSR8tUCApemVcfPtwNhQNPpW8KrlWUIMguHdg==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/client-sso": "3.52.0",
         "@aws-sdk/property-provider": "3.52.0",
@@ -8969,6 +10182,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.52.0.tgz",
       "integrity": "sha512-+4qz0PZn9u6HRRNBO9YfIixdItukixPOtLP8tNlgriCh66BC6M1mAXXP/uq2x7kIaMRZtTo3Eey4T/tA0QMkOg==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -9050,6 +10265,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.52.0.tgz",
       "integrity": "sha512-pFXkCeEIcrgH8esRyUab1nnIo1cjUjrheqwb/MK3gJ363/kenT6IqYXOq0UO4mF7bn6IOz/yxODlhQIU6i1Vww==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.52.0",
         "@aws-sdk/querystring-builder": "3.52.0",
@@ -9075,6 +10292,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.52.0.tgz",
       "integrity": "sha512-pN2dSSyyy0emFFtK6jgmzYXcJHITbfdPqR7UTQ1fj1wFvbURPN19C1f4uYbVDjuiUQX01hLclJDLnPy1BIzTGQ==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.52.0",
         "@aws-sdk/util-buffer-from": "3.52.0",
@@ -9096,6 +10315,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.52.0.tgz",
       "integrity": "sha512-TjRzfFFiY4i/a9ry5llCQMiIwpyhIyriM2QuPgAdRaRPM076I01FohUzlAc7zgwwhCa5rpI4zRZ+auGPrU44Gw==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
@@ -9110,11 +10331,11 @@
       }
     },
     "@aws-sdk/lib-dynamodb": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.52.0.tgz",
-      "integrity": "sha512-Ee+mRIgE+9BxAUlHiNaIP//iCbwGMWizmmnseFxXJW3tUZbdvNFGTH1fzp1UL0p+siqVotUTPSL6grWekWFiDg==",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-dynamodb/-/lib-dynamodb-3.53.0.tgz",
+      "integrity": "sha512-WTc4TB+mheEcRg3iVmJEibpaACfG8Jye2HLAvt/HoObcdd3J34ag1stRV/CZpYb/2DO2nzL+vo1E7Kl8hwpKHg==",
       "requires": {
-        "@aws-sdk/util-dynamodb": "3.52.0",
+        "@aws-sdk/util-dynamodb": "3.53.0",
         "tslib": "^2.3.0"
       }
     },
@@ -9162,6 +10383,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.52.0.tgz",
       "integrity": "sha512-U+aa8UswtEvEdt4vvX+C4b+vetSpG6PZVeGN/hZ2J0j3jQxODQtjKHU3VIO+Fvp8m9rSCtcfAPly5CcejHLeKw==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -9169,15 +10392,54 @@
       }
     },
     "@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.52.0.tgz",
-      "integrity": "sha512-qhDKtFEgEX8xpIKgM3h7qma3CORGrPXMB9s6zeRhYrJmH12uA9SjpSOSs5mZnvExbKuWxOK5ZULTIBprmV4WAg==",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.53.0.tgz",
+      "integrity": "sha512-VEa5I0zms9Q7nct0i51W+3Uu7M6koYda17fcMxISLqg7he7nZ3EiUFYh3bDDXoEvfI5Hw915DttTGQ6vkriaFg==",
       "requires": {
-        "@aws-sdk/config-resolver": "3.52.0",
+        "@aws-sdk/config-resolver": "3.53.0",
         "@aws-sdk/endpoint-cache": "3.52.0",
-        "@aws-sdk/protocol-http": "3.52.0",
-        "@aws-sdk/types": "3.52.0",
+        "@aws-sdk/protocol-http": "3.53.0",
+        "@aws-sdk/types": "3.53.0",
         "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@aws-sdk/config-resolver": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.53.0.tgz",
+          "integrity": "sha512-wAqP/xNx49H1dutHWHjhKduaKtAcDg2KoH25W6peW2qXZ6OfpVcxRIBbJE4Z0yGOmFFaxw0OeH3h2ptP7tdhGQ==",
+          "requires": {
+            "@aws-sdk/signature-v4": "3.53.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-config-provider": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.53.0.tgz",
+          "integrity": "sha512-lKOXq2FjQH2i/ztJOKHoNgJ9Kpaprhb6/lsKMjHuePr/YDEzp62nEuJKbVx5rA9C8Rxuuj2hE8vXhQ6dyUIsjg==",
+          "requires": {
+            "@aws-sdk/types": "3.53.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.53.0.tgz",
+          "integrity": "sha512-CUvCIrwiiWpJd/ldSA04RERXPsdvkuKW3+gBDIUREq4uc7co7Cml1/wbIJ0UOHAmJpDw82NDYqAUthYB1kbHrQ==",
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.52.0",
+            "@aws-sdk/types": "3.53.0",
+            "@aws-sdk/util-hex-encoding": "3.52.0",
+            "@aws-sdk/util-uri-escape": "3.52.0",
+            "tslib": "^2.3.0"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.53.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.53.0.tgz",
+          "integrity": "sha512-FqHfWRXdnQvfxgngDKfYpYOuQ1HmPgxaGKELx3pFaEnQdMo/dMXjfBGQcEQgP8jqU6bPLaJSfykjWjDzua8JBg=="
+        }
       }
     },
     "@aws-sdk/middleware-expect-continue": {
@@ -9209,6 +10471,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.52.0.tgz",
       "integrity": "sha512-t7y0gtJyFNrS6bwluR7N2LtppA7B0SDk+uNlvOJOYnJRms89fXltyMJWl8wrv8IHHvrhRLwNEP22vvOhn3hriA==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -9230,6 +10494,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.52.0.tgz",
       "integrity": "sha512-YbFuJAsOPvbYe64gpqmS6XmEQXwyAGwH3Y4iOp3CnrGAz/zXbwWwzb653Uby+h4PVkTZ1+RviCO/A6si9bUkhw==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
@@ -9239,6 +10505,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.52.0.tgz",
       "integrity": "sha512-O+4mfn7OPv1POYagKwOgdlc16AQFWa4bY05g6Y94KZ2400ywNpK+Y2cwdskyNU3OTGOlluVGR21W5eO1b+XhNg==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.52.0",
         "@aws-sdk/service-error-classification": "3.52.0",
@@ -9265,6 +10533,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.52.0.tgz",
       "integrity": "sha512-NB1wHvOp+I6DXi5fPutyl9dAWvJYqzRqdi8lMeu02ub/d6nybrAjoB56za1LvGblcoEiYClf1A6dTKtmydgzFQ==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/middleware-signing": "3.52.0",
         "@aws-sdk/property-provider": "3.52.0",
@@ -9278,6 +10548,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.52.0.tgz",
       "integrity": "sha512-4ZooINTdOI4+T6pEiu8xte5EEhOqbE/wqOwBzvOASk3JKElZ93u6xKP2u7UKVD6asBBYK2mDrYSy1PsU4fNl4A==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
@@ -9287,6 +10559,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.52.0.tgz",
       "integrity": "sha512-7FUqmZQ5DzaDJYCJ3YmOHRFEyFeohtsDQ1akWD2qekcjp16ftBtk05Fi9am5/L7pO8svVzobji/wg00Tlq183A==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.52.0",
         "@aws-sdk/protocol-http": "3.52.0",
@@ -9310,6 +10584,7 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.52.0.tgz",
       "integrity": "sha512-4OTbQ+tWc6Le7es3kSnXBzCyddcUw6Sk2GupR/1+PD9v4/qvtKXXK+uD4bMDDMfi6dTNV+2riOGBniOtBVsayw==",
+      "peer": true,
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -9318,6 +10593,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.52.0.tgz",
       "integrity": "sha512-sfdJvAp/f4PHmQvSklFAuCpD7gqloG502gSmBAMrXKqYykvQ5SAGyr6sCZPWf8CZxKtn5n4ftg8CLKywwrKwmg==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/protocol-http": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -9328,6 +10605,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.52.0.tgz",
       "integrity": "sha512-vfeTzkfVtGaNQrnhCRMObqid0shxFtNFEnnU1Nnx7HsgBfag2/T6fnsDzdVGaliQ6nmfg+RMrhzw2VECyBTHQQ==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.52.0",
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
@@ -9339,6 +10618,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.52.0.tgz",
       "integrity": "sha512-MjLkndwLuWye1kavyFnDw5BvK8Rg4YpMULTne++OL/uEsxWO786K+QQMyLWkirPe+ELMEYu/3eOrQTly2tqHsA==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/abort-controller": "3.52.0",
         "@aws-sdk/protocol-http": "3.52.0",
@@ -9351,6 +10632,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.52.0.tgz",
       "integrity": "sha512-Ooam7CvGefHKhMwQ413MiEtDTFw70xbCduJCF7Bg1F0WKrf700M/Yte+q3E0ljlXWJ28rwJNgwW3ptZaSXMGPg==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
@@ -9360,6 +10643,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.52.0.tgz",
       "integrity": "sha512-L6ITU9NG0L6nyYfzhSLa0EsgDlyL1vHNz+Om9o7TayUUF7O0f3UiZToWf2hdETQ04Os8625aZt0VH92ZnYyeEw==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
@@ -9369,6 +10654,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.52.0.tgz",
       "integrity": "sha512-RfNXqKeR6mdg2n2LO5Vs2Bz+f47/KN5k36HWk04bSwIbhnBtslXBp0F1KgSPkeP56KEgmmUWldRD7g8BvDkgAw==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.52.0",
         "@aws-sdk/util-uri-escape": "3.52.0",
@@ -9379,6 +10666,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.52.0.tgz",
       "integrity": "sha512-/A6PauieStZajbkxX3sZSBBDacGDc3I/Sk7rjJulmg1GnizeVcUgx1OUdDh1JasdqA1h9E3ks/Y2Lu3xUMctLw==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.52.0",
         "tslib": "^2.3.0"
@@ -9387,7 +10676,9 @@
     "@aws-sdk/service-error-classification": {
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.52.0.tgz",
-      "integrity": "sha512-2bpSIZCx5VGp2CBTeXK6PxlBYWrn2wiqxBVYstDRExZ8P7edcwPRgWi8qaKgPM2wvstZwJieF774niiuLddIpg=="
+      "integrity": "sha512-2bpSIZCx5VGp2CBTeXK6PxlBYWrn2wiqxBVYstDRExZ8P7edcwPRgWi8qaKgPM2wvstZwJieF774niiuLddIpg==",
+      "dev": true,
+      "peer": true
     },
     "@aws-sdk/shared-ini-file-loader": {
       "version": "3.52.0",
@@ -9401,6 +10692,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.52.0.tgz",
       "integrity": "sha512-lSlDASXGLup5v12kclzT2ZLoUnnVLknSRcMXrTVjnX7spmHMbs6s7LOcN0RXZzFIACs7vW+930KUzhBxt8UiFQ==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/is-array-buffer": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -9429,6 +10722,7 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.52.0.tgz",
       "integrity": "sha512-GuOJuoA1kky/v2p7byOZGq7YOiu2Ov8DA3d58gM6L/q7XavBjnzwNB/BYU7SPU3Ly6S7qGxBJFeadufic4bCYg==",
+      "peer": true,
       "requires": {
         "@aws-sdk/middleware-stack": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -9444,6 +10738,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.52.0.tgz",
       "integrity": "sha512-/9OJwol/384jsISiAs5JX7fkgd9mv7hJsHFCVXnByim5qTZu1V9fMcJYJ1L3iRmfCRy0w75UDJljIx2RZnwAYw==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/querystring-parser": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -9514,6 +10810,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-credentials/-/util-credentials-3.52.0.tgz",
       "integrity": "sha512-fNcm2cNzDHWt5Pr6xD2FXA40jkcgClsbumuI0VBhLEyNLfoetwPImKTpqbxo1XfWVxhqIbT/ELnrbS2OYBRIXg==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/shared-ini-file-loader": "3.52.0",
         "tslib": "^2.3.0"
@@ -9523,6 +10821,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.52.0.tgz",
       "integrity": "sha512-N2/DHJ/OfiQ5zP97k9cJ8jSGiWDjtR7oFqXR+wbKZzKOww6vencMPYlndU6v1uZOKEjoj+NBr5N0jPEjCz+6+g==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/property-provider": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -9534,6 +10834,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.52.0.tgz",
       "integrity": "sha512-vmbvirg5edfNKBin8Mup2noxgqIYzYPnvk+BgIx3jFPvwT57WGRs/ahOMNqHgv/6xAdVaUjz8g7gw9Yy3mwP3A==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/config-resolver": "3.52.0",
         "@aws-sdk/credential-provider-imds": "3.52.0",
@@ -9544,9 +10846,9 @@
       }
     },
     "@aws-sdk/util-dynamodb": {
-      "version": "3.52.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.52.0.tgz",
-      "integrity": "sha512-Y7ehxs4+D4d8+zWqVrZ9BfDsdGSzpzywQjUnP6Zqm+yzzcgttjjEE3NgQQjWtoYqrjfZcZkCo3mb5x6PjYMcLg==",
+      "version": "3.53.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.53.0.tgz",
+      "integrity": "sha512-YY9dSk/VcuJAZRG1xE8DN1D3dhqEHmefw3cNt+Aecqu+bp7Zx5/sd1FbdyDg3+QKme6hPkuZHtleiohhC8TvEQ==",
       "requires": {
         "tslib": "^2.3.0"
       }
@@ -9579,6 +10881,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.52.0.tgz",
       "integrity": "sha512-zmw9pJ91QAr1oF3uqLKuo/3++NrSEagLwz3xnuID5wN8WLAgbC6MkvM7FG+r11CHSoUX3IeB6YDqoBMQW8en8w==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/types": "3.52.0",
         "bowser": "^2.11.0",
@@ -9589,6 +10893,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.52.0.tgz",
       "integrity": "sha512-jqbyb6R4goWOTIESizmNPy1i3Xa25Q3QG0xt6Pct0DwLQUSVpnPHw07NmfRhql+eYBoD4uxpXDX9lWsuLUBi0w==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/node-config-provider": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -9616,6 +10922,8 @@
       "version": "3.52.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.52.0.tgz",
       "integrity": "sha512-8Gx0NunIg1RFpnKSA3nwzDl5j8mJ42kWjy5sHgd4wfUyiXRSvTl69sV6O8qhleI9OMDV0iS4xHZBCLK11HdIoA==",
+      "dev": true,
+      "peer": true,
       "requires": {
         "@aws-sdk/abort-controller": "3.52.0",
         "@aws-sdk/types": "3.52.0",
@@ -10057,9 +11365,9 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.1.0.tgz",
-      "integrity": "sha512-C1DfL7XX4nPqGd6jcP01W9pVM1HYCuUkFk1432D7F0v3JSlUIeOYn9oCoi3eoLZ+iwBSb29BMFxxny0YrrEZqg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.2.0.tgz",
+      "integrity": "sha512-igm9SjJHNEJRiUnecP/1R5T3wKLEJ7pL6e2P+GUSfCd0dGjPYYZve08uzw8L2J8foVHFz+NGu12JxRcU2gGo6w==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -10565,12 +11873,12 @@
       }
     },
     "@types/jest": {
-      "version": "27.4.0",
-      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.0.tgz",
-      "integrity": "sha512-gHl8XuC1RZ8H2j5sHv/JqsaxXkDDM9iDOgu0Wp8sjs4u/snb2PVehyWXJPr+ORA0RPpgw231mnutWI1+0hgjIQ==",
+      "version": "27.4.1",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-27.4.1.tgz",
+      "integrity": "sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==",
       "dev": true,
       "requires": {
-        "jest-diff": "^27.0.0",
+        "jest-matcher-utils": "^27.0.0",
         "pretty-format": "^27.0.0"
       }
     },
@@ -11932,12 +13240,12 @@
       }
     },
     "eslint": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.9.0.tgz",
-      "integrity": "sha512-PB09IGwv4F4b0/atrbcMFboF/giawbBLVC7fyDamk5Wtey4Jh2K+rYaBhCAbUyEI4QzB1ly09Uglc9iCtFaG2Q==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.10.0.tgz",
+      "integrity": "sha512-tcI1D9lfVec+R4LE1mNDnzoJ/f71Kl/9Cv4nG47jOueCMBrCCKYXr4AUVS7go6mWYGFD4+EoN6+eXSrEbRzXVw==",
       "dev": true,
       "requires": {
-        "@eslint/eslintrc": "^1.1.0",
+        "@eslint/eslintrc": "^1.2.0",
         "@humanwhocodes/config-array": "^0.9.2",
         "ajv": "^6.10.0",
         "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
   "author": "mhlabs",
   "license": "ISC",
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "^3.51.0",
-    "@aws-sdk/lib-dynamodb": "^3.51.0"
+    "@aws-sdk/client-dynamodb": "^3.53.0",
+    "@aws-sdk/lib-dynamodb": "^3.53.0"
   },
   "devDependencies": {
-    "@types/jest": "^27.4.0",
+    "@types/jest": "^27.4.1",
     "aws-sdk-client-mock": "^0.6.0",
-    "eslint": "^8.7.0",
+    "eslint": "^8.10.0",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.25.4",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
+    "aws-sdk-client-mock": "^0.6.0",
     "eslint": "^8.7.0",
     "eslint-config-airbnb-base": "15.0.0",
     "eslint-config-prettier": "^8.3.0",


### PR DESCRIPTION
Two things to consider:

1) Do we want to use the GetCommand or just use the getItem function on the document client? Not really a fan of the send syntax in this context after working with it for a while, but both AWS mocking module and the community in general seems to favour that over the direct functions which seems to be regarded as kept only for legacy/compatibility reasons.

2) Is the exporting mechanism in index.js a good way to structure the lib? Thinking it could be good to hide the instantiation of the document client etc. from clients of this lib and also has the advantage that we only init one instance of the client per lambda instance, but the syntax is a little clumsy and intellisense etc. gets harder when passing in the instance from the calling function.