### PR TITLE
chore: prohibit multidimensional arrays in batchwrite

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mhlabs/dynamodb-client",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A lib to simplify working with dynamodb documentclient in aws sdk v3.",
   "main": "index.js",
   "jest": {

--- a/src/array/isMultidimensional.js
+++ b/src/array/isMultidimensional.js
@@ -1,0 +1,7 @@
+function isMultidimensional(array) {
+  return Array.isArray(array) && array.some((value) => Array.isArray(value));
+}
+
+module.exports = {
+  isMultidimensional
+};

--- a/src/array/isMultidimensional.test.js
+++ b/src/array/isMultidimensional.test.js
@@ -1,0 +1,17 @@
+const { isMultidimensional } = require('./isMultidimensional');
+
+describe('isMultidimensional', () => {
+  const isNotMultidimensionalCases = [[[1, 2]], [[]], [null]];
+  it.each(isNotMultidimensionalCases)(
+    'should not be multidimensional',
+    (value) => {
+      const res = isMultidimensional(value);
+      expect(res).toEqual(false);
+    }
+  );
+
+  it('should be multidimensional', () => {
+    const res = isMultidimensional([1, [2, 3]]);
+    expect(res).toEqual(true);
+  });
+});

--- a/src/dynamodb/batch/write.js
+++ b/src/dynamodb/batch/write.js
@@ -28,7 +28,7 @@ function ensureValidParameters(documentClient, tableName, items) {
   if (!tableName) throw new Error('Table name is required.');
   if (!items) throw new Error('Item list is required.');
   if (isMultidimensional(items))
-    throw new Error("Item list can't contain arrays (multidimensional).");
+    throw new Error("Item list can't contain arrays (be multidimensional).");
 }
 
 async function batchWrite(

--- a/src/dynamodb/batch/write.js
+++ b/src/dynamodb/batch/write.js
@@ -8,6 +8,7 @@ const {
   filterUniqueObjects,
   defaultDuplicateOptions
 } = require('./duplicate-handling/filter');
+const { isMultidimensional } = require('../../array/isMultidimensional');
 
 function createBatchWriteCommand(tableName, batch) {
   const putRequests = batch.map((item) => ({
@@ -26,6 +27,8 @@ function ensureValidParameters(documentClient, tableName, items) {
   if (!documentClient) throw new Error('documentClient is required.');
   if (!tableName) throw new Error('Table name is required.');
   if (!items) throw new Error('Item list is required.');
+  if (isMultidimensional(items))
+    throw new Error("Item list can't be multidimensional.");
 }
 
 async function batchWrite(

--- a/src/dynamodb/batch/write.js
+++ b/src/dynamodb/batch/write.js
@@ -28,7 +28,7 @@ function ensureValidParameters(documentClient, tableName, items) {
   if (!tableName) throw new Error('Table name is required.');
   if (!items) throw new Error('Item list is required.');
   if (isMultidimensional(items))
-    throw new Error("Item list can't be multidimensional.");
+    throw new Error("Item list can't contain arrays (multidimensional).");
 }
 
 async function batchWrite(

--- a/src/dynamodb/batch/write.test.js
+++ b/src/dynamodb/batch/write.test.js
@@ -22,6 +22,9 @@ describe('batchWrite', () => {
 
   it('should validate item list', async () => {
     await expect(tested({}, 'table')).rejects.toThrow('Item list is required.');
+    await expect(tested({}, 'table', [1, [2, 3]])).rejects.toThrow(
+      'Item list should not be multidimensional.'
+    );
   });
 
   it('should split items into chunks of max batch size (batchWrite limit)', async () => {

--- a/src/dynamodb/batch/write.test.js
+++ b/src/dynamodb/batch/write.test.js
@@ -23,7 +23,7 @@ describe('batchWrite', () => {
   it('should validate item list', async () => {
     await expect(tested({}, 'table')).rejects.toThrow('Item list is required.');
     await expect(tested({}, 'table', [1, [2, 3]])).rejects.toThrow(
-      'Item list should not be multidimensional.'
+      "Item list can't contain arrays (multidimensional)."
     );
   });
 

--- a/src/dynamodb/batch/write.test.js
+++ b/src/dynamodb/batch/write.test.js
@@ -23,7 +23,7 @@ describe('batchWrite', () => {
   it('should validate item list', async () => {
     await expect(tested({}, 'table')).rejects.toThrow('Item list is required.');
     await expect(tested({}, 'table', [1, [2, 3]])).rejects.toThrow(
-      "Item list can't contain arrays (multidimensional)."
+      "Item list can't contain arrays (be multidimensional)."
     );
   });
 


### PR DESCRIPTION
I accidentally tried batchWrite with a multidimensional array, this fix will result in a better error message.

Error message I got:
```
ERROR	TypeError: Cannot read property '0' of undefined
    at Object.AttributeValue.visit (/var/task/node_modules/@mhlabs/dynamodb-client/node_modules/@aws-sdk/client-dynamodb/dist-cjs/models/models_0.js:1319:40)
    at serializeAws_json1_0AttributeValue (/var/task/node_modules/@mhlabs/dynamodb-client/node_modules/@aws-sdk/client-dynamodb/dist-cjs/protocols/Aws_json1_0.js:3134:38)
    at /var/task/node_modules/@mhlabs/dynamodb-client/node_modules/@aws-sdk/client-dynamodb/dist-cjs/protocols/Aws_json1_0.js:4047:20
    at Array.reduce (<anonymous>)
```