### PR TITLE
feat: add possibility to init with client as parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -87,8 +87,23 @@ function init(dynamoDbClientConfig = undefined, translateConfig = undefined) {
   return createDynamoClient(documentClient);
 }
 
+function initWithClient(client, translateConfig = undefined) {
+  const translateOptions = { ...translateConfig };
+
+  if (!translateOptions.marshallOptions) {
+    translateOptions.marshallOptions = {
+      removeUndefinedValues: true
+    };
+  }
+
+  const documentClient = DynamoDBDocument.from(client, translateOptions);
+
+  return createDynamoClient(documentClient);
+}
+
 const dynamoClient = {
-  init
+  init,
+  initWithClient
 };
 
 module.exports = dynamoClient;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mhlabs/dynamodb-client",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A lib to simplify working with dynamodb documentclient in aws sdk v3.",
   "main": "index.js",
   "jest": {


### PR DESCRIPTION
Need to be able to pass in a client that I initialise in my own code. Mainly to be able to trace it https://awslabs.github.io/aws-lambda-powertools-typescript/latest/core/tracer/#methods